### PR TITLE
OWA-34: Implement functionality to list addons in Add-on Manager Page

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,7 +47,7 @@
     "react/jsx-indent-props": 0,
     "react/jsx-key": 1,
     "react/jsx-max-props-per-line": 0,
-    "react/jsx-no-bind": 1,
+    "react/jsx-no-bind": 0,
     "react/jsx-no-duplicate-props": 1,
     "react/jsx-no-literals": 0,
     "react/jsx-no-undef": 1,

--- a/app/css/openmrs-addonmanager.css
+++ b/app/css/openmrs-addonmanager.css
@@ -53,6 +53,7 @@ header .logo img {
     border-radius: 5px;
     min-height: 500px;
     justify-content: center;
+    overflow: auto;
 }
 
 .app-title {
@@ -259,4 +260,21 @@ legend.scheduler-border {
     width:inherit; /* Or auto */
     padding:0 10px; /* To give a bit of padding on the left and right */
     border-bottom:none;
+}
+
+.addon-name {
+    font-weight: bold;
+}
+
+.addon-description {
+    margin-top: 3px;
+}
+
+.delete-icon {
+    font-size: 20px;
+    color: #a94442;
+}
+
+td {
+    cursor: pointer;
 }

--- a/app/js/components/homePage/manageApps/addonList.jsx
+++ b/app/js/components/homePage/manageApps/addonList.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export const AddonList = ({appList, openPage}) => {
+  return (
+    <tbody>
+      {
+        appList.map((app, key) => {
+          return (
+            <tr key={key}>
+              <td onClick={() => openPage(app)}>
+                <img
+                  src={`/${location.href.split('/')[3]}/owa/openmrs-addonmanager/${app.icons[48]}`}
+                  alt="addon logo"
+                />
+              </td>
+              <td onClick={() => openPage(app)}>
+                <div className="addon-name">{app.name}</div>
+                <div><h5  className="addon-description">{app.description}</h5></div>
+              </td>
+              <td onClick={() => openPage(app)}>
+                {app.developer.name}
+              </td>
+              <td onClick={() => openPage(app)}>
+                {app.version}
+              </td>
+              <td className="text-center">
+                <a href="#">
+                  <i className="glyphicon glyphicon-trash text-danger delete-icon"/>
+                </a>
+              </td>
+            </tr>
+          );
+        })
+      }
+    </tbody>
+  );
+};
+
+AddonList.propTypes = {
+  appList: React.PropTypes.array.isRequired,
+  openPage: React.PropTypes.func.isRequired,
+};

--- a/app/js/components/homePage/manageApps/manageApps.jsx
+++ b/app/js/components/homePage/manageApps/manageApps.jsx
@@ -10,13 +10,30 @@ import React from 'react';
 import fetchPolyfill from 'whatwg-fetch';
 import AddAddon from '../manageApps/AddAddon.jsx';
 import { ApiHelper } from '../../../helpers/apiHelper';
+import { AddonList } from './addonList';
 
 export default class ManageApps extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      appList: []
+    };
 
+    this.openPage = this.openPage.bind(this);
     this.handleClear = this.handleClear.bind(this);
     this.handleUpload = this.handleUpload.bind(this);  
+  }
+
+  componentWillMount() {
+    const apiHelper = new ApiHelper(null);
+    apiHelper.get('/owa/applist').then(response => {
+      if (response.error) throw response.error.message;
+      this.setState((prevState, props) => {
+        return {
+          appList: response
+        };
+      });
+    });
   }
   
   componentDidMount() {
@@ -46,6 +63,10 @@ export default class ManageApps extends React.Component {
 
   handleClear() {
     $(":file").filestyle('clear');
+  }  
+
+  openPage(app) {
+    return location.href = `/${location.href.split('/')[3]}/owa/${app.folderName}/${app.launch_path}`;
   }
 
   render() {
@@ -67,9 +88,7 @@ export default class ManageApps extends React.Component {
                 <th>Delete</th>
               </tr>
             </thead>
-            <tbody>
-              <tr />
-            </tbody>
+            <AddonList appList={this.state.appList} openPage={this.openPage}/>
           </table>
         </div>
       </div>

--- a/tests/homepage/addonList.test.js
+++ b/tests/homepage/addonList.test.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount, shallow } from 'enzyme';
+import  { AddonList }  from '../../app/js/components/homePage/manageApps/addonList';
+
+
+describe('<AddonList />', () => {
+    const appList = [{
+        "version": "1.0.0",
+        "name": "CohortBuilder",
+        "description": "modern refresh of the OpenMRS Cohort Builder tool",
+        "icons": {
+            "16": null,
+            "48": "/img/omrs-button.png",
+            "128": null
+        },
+        "developer": {
+            "url": "https://github.com/openmrs/openmrs-owa-cohortbuilder",
+            "name": "andela-odaniel, wanjikum, andela-jomadoye, andela-pupendo, kingisaac95",
+            "company": null,
+            "email": null
+        },
+        "activities": {
+            "openmrs": {
+                "href": "*"
+            }
+        },
+        "folderName": "cohortbuilder",
+        "baseUrl": null,
+        "launchUrl": null,
+        "launch_path": "index.html",
+        "installs_allowed_from": null,
+        "default_locale": "en",
+        "deployed.owa.name": null
+    },];
+
+    const openPage = () => {};
+    const addonList = mount( < AddonList appList={appList} openPage={openPage} / > );
+    
+    it('should render a tbody', () => {
+        expect(addonList.find("tbody")).to.have.length(1);
+    });
+    
+    it('should render a tr tag', () => {
+        expect(addonList.find("tr")).to.have.length(1);
+    });
+    
+    it('should render td tag', () => {
+        expect(addonList.find("td")).to.have.length(5);
+    });
+    
+    it('should render div tags', () => {
+        expect(addonList.find("div")).to.have.length(2);
+    });
+
+    it('should render a h2 tag', () => {
+        expect(addonList.find("h5")).to.have.length(1);
+    });
+
+    it('should render a image tag', () => {
+        expect(addonList.find("img")).to.have.length(1);
+    });
+    
+    it('should render an anchor tag', () => {
+        expect(addonList.find("a")).to.have.length(1);
+    });
+});


### PR DESCRIPTION
## JIRA TICKET NAME:
OWA-34 - [Implement functionality to list OWAs on Add-on Management page](https://issues.openmrs.org/browse/OWA-34)

### SUMMARY:
Users should see a table where all OWAs are listed with their details
The Add-on Manager should be able to list currently available OWAs. 
The OWA in the list should be clickable to redirect the user to OWA entry point

#### Screenshot
<img width="888" alt="screen shot 2017-09-11 at 8 50 04 pm" src="https://user-images.githubusercontent.com/26261917/30293918-16ccf9e2-9733-11e7-996c-719c21eaed39.png">
