### PR TITLE
Write tests for the delete modal and activate toastr notifications

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,9 +6,11 @@
   <link rel="shortcut icon" type="image/ico" href="../../images/openmrs-favicon.ico"/>
   <link rel="icon" type="image/png" href="../../images/openmrs-favicon.png"/>
   <link rel="stylesheet" href="libs/bootstrap/dist/css/bootstrap.css" />
+  <link rel="stylesheet" href="libs/toastr/toastr.min.css"/>
   <script src="libs/jquery/dist/jquery.min.js" ></script>
   <script src="libs/bootstrap/dist/js/bootstrap.min.js" ></script>
   <script src="libs/bootstrap-filestyle/src/bootstrap-filestyle.min.js" ></script>
+  <script src="libs/toastr/toastr.min.js" ></script>
 </head>
 <body>  
 <div class="clear"></div>

--- a/app/js/components/homePage/manageApps/manageApps.jsx
+++ b/app/js/components/homePage/manageApps/manageApps.jsx
@@ -13,6 +13,7 @@ import BreadCrumbComponent from '../../breadCrumb/breadCrumbComponent';
 import { ApiHelper } from '../../../helpers/apiHelper';
 import { AddonList } from './addonList';
 import DeleteAddonModal from './deleteAddonModal.jsx';
+import Utility from './../../../utility';
 
 export default class ManageApps extends React.Component {
   constructor(props) {
@@ -151,6 +152,7 @@ export default class ManageApps extends React.Component {
           msgType: 'success' 
         };
       });
+      Utility.notifications('error', name + ' deleted successfully');
     }).catch(error => {
       toastr.error(error);
     });

--- a/app/js/utility/index.js
+++ b/app/js/utility/index.js
@@ -1,0 +1,15 @@
+/* 
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+import notifications from '../utility/notificationHandler';
+
+export default {
+  notifications
+};

--- a/app/js/utility/notificationHandler.js
+++ b/app/js/utility/notificationHandler.js
@@ -1,0 +1,49 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+/**
+ * This method handles all notifications on the system
+ * *
+ * 
+ * @param {String} type the type of notification
+ * @param {String} message the message to display
+ * @returns {Function} function that displays an error message
+ */
+export default function handleNotification(type, message) {
+  toastr.options = {
+    "closeButton": false,
+    "debug": false,
+    "newestOnTop": false,
+    "progressBar": false,
+    "positionClass": "toast-top-right",
+    "preventDuplicates": false,
+    "onclick": null,
+    "showDuration": "300",
+    "hideDuration": "2000",
+    "timeOut": "1000",
+    "extendedTimeOut": "1000",
+    "showEasing": "swing",
+    "hideEasing": "linear",
+    "showMethod": "fadeIn",
+    "hideMethod": "fadeOut"
+  };
+
+  if (type === 'info') {
+    toastr.info(message);
+  } else if (type === 'error') {
+    toastr.error(message);
+  } else if (type === 'warning') {
+    toastr.warning(message);
+  } else if (type === 'success') {
+    toastr.success(message);
+  } else {
+    toastr.error('Error encountered');
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "bootstrap": "3.3.7",
-    "bootstrap-filestyle": "1.3.0"
+    "bootstrap-filestyle": "1.3.0",
+    "toastr": "^2.1.3"
   }
 }

--- a/tests/homepage/deleteModal.test.js
+++ b/tests/homepage/deleteModal.test.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import DeleteModal from '../../app/js/components/homePage/manageApps/deleteAddonModal';
+
+describe('<DeleteModal />', () => {
+    const selectedApp = {
+        "version": "1.0.0",
+        "name": "CohortBuilder",
+        "description": "modern refresh of the OpenMRS Cohort Builder tool",
+        "icons": {
+            "16": null,
+            "48": "/img/omrs-button.png",
+            "128": null
+        },
+        "developer": {
+            "url": "https://github.com/openmrs/openmrs-owa-cohortbuilder",
+            "name": "andela-odaniel, wanjikum, andela-jomadoye, andela-pupendo, kingisaac95",
+            "company": null,
+            "email": null
+        },
+        "activities": {
+            "openmrs": {
+                "href": "*"
+            }
+        },
+        "folderName": "cohortbuilder",
+        "baseUrl": null,
+        "launchUrl": null,
+        "launch_path": "index.html",
+        "installs_allowed_from": null,
+        "default_locale": "en",
+        "deployed.owa.name": null
+    };
+    const renderedComponent = 
+    shallow( < DeleteModal 
+        app={selectedApp} 
+        handleDelete= {(CohortBuilder) => {}}
+        isOpen={true}  
+        hideModal= {() => {}}/ > 
+        );
+    
+    it('should render a Modal', () => {
+        expect(renderedComponent.find("Modal")).to.have.length(1);
+    });
+
+    it('should render a ModalHeader', () => {
+        expect(renderedComponent.find("ModalHeader")).to.have.length(1);
+    });
+
+    it('should render a ModalClose', () => {
+        expect(renderedComponent.find("ModalClose")).to.have.length(1);
+    });
+
+    it('should render a ModalTitle', () => {
+        expect(renderedComponent.find("ModalTitle")).to.have.length(1);
+    });
+
+    it('should render a ModalBody', () => {
+        expect(renderedComponent.find("ModalBody")).to.have.length(1);
+    });
+
+    it('should render a p tag', () => {
+        expect(renderedComponent.find("p")).to.have.length(1);
+    });
+
+    it('should render a ModalFooter', () => {
+        expect(renderedComponent.find("ModalFooter")).to.have.length(1);
+    });
+
+    it('should render a button', () => {
+        expect(renderedComponent.find("button")).to.have.length(2);
+    });
+}); 


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-31](https://issues.openmrs.org/browse/AOM-31)
Write tests for the delete modal and activate toastr notification

### SUMMARY:
- After a user has successfully deleted an add-on, there should be a toastr message that notifies the user that the add-on has indeed been deleted.
- Write tests that takes care of the delete modal.