### PR TITLE
AOM-33: Fix the different style of OpenMRS breadcrumbs in the Add-On Manager

### DIFF
--- a/app/js/components/breadCrumb/BreadCrumbComponent.jsx
+++ b/app/js/components/breadCrumb/BreadCrumbComponent.jsx
@@ -9,7 +9,7 @@
  */
 
 import React, {Component} from 'react';
-import { Link } from 'react-router';
+import { Link, browserHistory } from 'react-router';
 import './breadCrumb.css';
 
 class BreadCrumbComponent extends Component{
@@ -23,26 +23,28 @@ class BreadCrumbComponent extends Component{
     };
   }
   componentWillMount(){
-    const currentTab = window.location.href.split('/').pop();
-    if (currentTab === '/') {
-      this.setState({
-        homePage: true,
-        manageSettingsPage: false,
-        manageAddonPage: false,
-      });
-    } else if(currentTab === 'manageSettings') {
-      this.setState({
-        manageSettingsPage: true,
-        manageAddonPage: false,
-        homePage: false
-      });
-    }else if (currentTab === 'manageApps') {
-      this.setState({
-        manageAddonPage: true,
-        manageSettingsPage: false,
-        homePage: false,
-      });
-    }
+    browserHistory.listen( location => {
+      const currentTab = location.hash.split('/').pop();
+      if (!currentTab) {
+        this.setState({
+          homePage: true,
+          manageSettingsPage: false,
+          manageAddonPage: false,
+        });
+      } else if(currentTab === 'manageSettings') {
+        this.setState({
+          manageSettingsPage: true,
+          manageAddonPage: false,
+          homePage: false
+        });
+      }else if (currentTab === 'manageApps') {
+        this.setState({
+          manageAddonPage: true,
+          manageSettingsPage: false,
+          homePage: false,
+        });
+      }
+    });
   }
 
   render(){

--- a/app/js/components/breadCrumb/breadCrumb.css
+++ b/app/js/components/breadCrumb/breadCrumb.css
@@ -13,6 +13,8 @@
     margin-bottom: 0px;
     padding-bottom: 0px;
     margin-top: 0px;
+    font-size: 0.9em; 
+    border-bottom: 1px solid white;
 }
 
 .breadcrumb .breadcrumb-item {

--- a/app/js/components/common/Header.js
+++ b/app/js/components/common/Header.js
@@ -11,6 +11,7 @@
 import React, {Component} from 'react';
 import {Link, IndexLink} from 'react-router';
 import {ApiHelper} from '../../helpers/apiHelper';
+import BreadCrumbComponent from '../breadCrumb/BreadCrumbComponent';
 
 const NUMBER_OF_COLUMNS = 3;
 
@@ -120,63 +121,46 @@ export default class Header extends Component {
 
   render() {
     return (
-      <header>
-        <div className="logo">
-          <a href="../../">
-            <img src="img/openmrs-with-title-small.png"/>
-          </a>
-        </div>
-
-        <ul className="navbar-right nav-header">
-          <li className="dropdown">
-            <a 
-              className="dropdown-toggle" 
-              data-toggle="dropdown" 
-              href="#" role="button" 
-              aria-haspopup="true" 
-              aria-expanded="false">
-              <span className="glyphicon glyphicon-user navbar-glyphicon-font"/> {' ' + this.state.currentUser}
-              <span className="caret navbar-glyphicon-font"/>
+      <div>
+        <header>
+          <div className="logo">
+            <a href="../../">
+              <img src="img/openmrs-with-title-small.png"/>
             </a>
-            <ul className="dropdown-menu profile-dropdown">
-              <li>
-                <a 
-                  className="my-account text-center"
-                  id="my-account"
-                  href="#">My Account</a>
-              </li>
-            </ul>
-          </li>
+          </div>
 
-          <li className="dropdown dropdown-large">
-            <a 
-              className="dropdown-toggle header-location" 
-              data-toggle="dropdown" 
-              href="#" 
-              role="button" 
-              aria-haspopup="true" 
-              aria-expanded="false">
-              <span className="glyphicon glyphicon glyphicon-map-marker navbar-glyphicon-font"/> {(this.state.currentLocationTag != "")
-                ? this.state.currentLocationTag
-                : this.state.defaultLocation}
-              <span className="caret navbar-glyphicon-font"/>
-            </a>
-            <ul 
-              id="location-ul"
-              className="dropdown-menu dropdown-menu-large row">
-              {this.dropDownMenu(this.getLocations())}
-            </ul>
-          </li>
-
-          <li>
-            <a 
-              className="navbar-font"
-              href={this.state.currentLogOutUrl}>Logout {' '}
-              <span className="glyphicon glyphicon-log-out navbar-glyphicon-font"/>
-            </a>
-          </li>
-        </ul>
-      </header>
+          <ul className="navbar-right nav-header">
+            <li className="dropdown">
+              <a className="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+                <span className="glyphicon glyphicon-user"/> {' ' + this.state.currentUser}
+                <span className="caret"/>
+              </a>
+              <ul className="dropdown-menu user">
+                <li>
+                  <a href="#">My Account</a>
+                </li>
+              </ul>
+            </li>
+            <li className="dropdown dropdown-large">
+              <a className="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
+                <span className="glyphicon glyphicon glyphicon-map-marker"/> {(this.state.currentLocationTag != "")
+                  ? this.state.currentLocationTag
+                  : this.state.defaultLocation}
+                <span className="caret"/>
+              </a>
+              <ul className="dropdown-menu dropdown-menu-large row">
+                {/*Execute the function*/}
+                {this.dropDownMenu(this.getLocations())}
+              </ul>
+            </li>
+            <li>
+              <a href={this.state.currentLogOutUrl}>Logout {' '}
+                <span className="glyphicon glyphicon-log-out"/></a>
+            </li>
+          </ul>
+        </header>
+        <BreadCrumbComponent />
+      </div>
     );
   }
 }

--- a/app/js/components/homePage/HomePage.jsx
+++ b/app/js/components/homePage/HomePage.jsx
@@ -8,13 +8,11 @@
  */
 import React, { Component } from 'react';
 import { Router, Route, Link, IndexRoute, hashHistory, browserHistory } from 'react-router';
-import BreadCrumbComponent from '../breadCrumb/BreadCrumbComponent';
 
 export default class HomePage extends React.Component {
   render() {
     return (
       <div>
-        <BreadCrumbComponent />
         <div className="main-home-page">
           <h2>Add On Manager</h2>
           <div className="home-page-body">

--- a/app/js/components/homePage/ManageSettings.jsx
+++ b/app/js/components/homePage/ManageSettings.jsx
@@ -8,7 +8,6 @@
  */
 import React from 'react';
 import { Link } from 'react-router';
-import BreadCrumbComponent from '../breadCrumb/BreadCrumbComponent';
 
 export default class ManageSettings extends React.Component {
   constructor(props) {
@@ -84,7 +83,6 @@ export default class ManageSettings extends React.Component {
     } = this.state;
     return (
       <div>
-        <BreadCrumbComponent />
         <br />
         <div className="container-fluid">
           <form className="form-horizontal">

--- a/app/js/components/homePage/manageApps/ManageApps.jsx
+++ b/app/js/components/homePage/manageApps/ManageApps.jsx
@@ -9,7 +9,6 @@
 import React from 'react';
 import axios from 'axios';
 import AddAddon from '../manageApps/AddAddon.jsx';
-import BreadCrumbComponent from '../../breadCrumb/BreadCrumbComponent';
 import { ApiHelper } from '../../../helpers/apiHelper';
 import { AddonList } from './AddonList';
 import DeleteAddonModal from './DeleteAddonModal.jsx';
@@ -233,7 +232,6 @@ export default class ManageApps extends React.Component {
 
     return (
       <div>
-        <BreadCrumbComponent />
         <div className="container-fluid">
           {this.state.showMsg ? alert : null}
           {showProgress === true ? progressBar : null}

--- a/tests/homepage/Header.test.js
+++ b/tests/homepage/Header.test.js
@@ -12,12 +12,17 @@ import React from 'react';
 import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
 import  Header  from '../../app/js/components/common/Header';
+import BreadCrumbComponent from '../../app/js/components/breadCrumb/BreadCrumbComponent';
 
 
 describe('<Header />', () => {
     const renderedComponent = shallow( < Header / > );
     it('Should render its children', () => {
-        expect(renderedComponent.find("div")).to.have.length(1);
+        expect(renderedComponent.find("div")).to.have.length(2);
+    });
+
+    it('should mount the BreadCrumbComponent in itself', () => {
+        expect(renderedComponent.contains( <BreadCrumbComponent/> )).to.equal(true);
     });
 
     it('Ensures the dropDownMenu populates the fetch locations', () => {

--- a/tests/homepage/Homepage.test.js
+++ b/tests/homepage/Homepage.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import HomePage from '../../app/js/components/homePage/HomePage';
-import BreadCrumbComponent from '../../app/js/components/breadCrumb/BreadCrumbComponent';
 
 describe('<Homepage />', () => {
     const homePage = shallow(< HomePage />);
@@ -30,7 +29,4 @@ describe('<Homepage />', () => {
         expect(homePage.find("Link").getNodes()).to.have.length(2);
     });
 
-    it('should mount the BreadCrumbComponent in itself', () => {
-        expect(homePage.contains( <BreadCrumbComponent/> )).to.equal(true);
-    });
 });

--- a/tests/homepage/ManageAddon.test.js
+++ b/tests/homepage/ManageAddon.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import ManageApps from '../../app/js/components/homePage/manageApps/ManageApps';
-import BreadCrumbComponent from '../../app/js/components/breadCrumb/BreadCrumbComponent';
 import AddonList from '../../app/js/components/homePage/manageApps/AddonList';
 
 describe('<ManageApps />', () => {
@@ -41,10 +40,6 @@ describe('<ManageApps />', () => {
             .props.children).to.equal('Version');
         expect(renderedComponent.find("th").getNodes()[4]
             .props.children).to.equal('Delete');
-    });
-
-    it('should mount the BreadCrumbComponent in itself', () => {
-        expect(renderedComponent.contains( <BreadCrumbComponent /> )).to.equal(true);
     });
 
     it('should mount the AddonList component in itself', () => {

--- a/tests/homepage/ManageSettings.test.js
+++ b/tests/homepage/ManageSettings.test.js
@@ -12,7 +12,6 @@ import React from 'react';
 import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
 import  ManageSettings  from '../../app/js/components/homePage/ManageSettings.jsx';
-import BreadCrumbComponent from '../../app/js/components/breadCrumb/BreadCrumbComponent';
 
 
 describe('<ManageSettings />', () => {
@@ -47,9 +46,4 @@ describe('<ManageSettings />', () => {
         expect(renderedComponent.find("legend")).to.have.length(1);
         expect(renderedComponent.find("legend").props().children).equals('Manage OWA Settings');
     });
-
-    it('should mount the BreadCrumbComponent in itself', () => {
-        expect(renderedComponent.contains( <BreadCrumbComponent/> )).to.equal(true);
-    });
-
 });


### PR DESCRIPTION
## JIRA TICKET NAME:

[AOM-33](https://issues.openmrs.org/browse/AOM-33)
Fix the different style of OpenMRS breadcrumbs in the Add-On Manager

### SUMMARY:

We are using some different style of breadcrumbs in the OpenMRS OWA. Usually, It should come between the header and the body part. But in the Add-Ons Manager OWA, It is located inside the body part. So It should be moved between the header and body part as usual.
