### PR TITLE
AOM-42: Fix bug in online search for addons

### DIFF
--- a/app/js/components/manageApps/AddonList.jsx
+++ b/app/js/components/manageApps/AddonList.jsx
@@ -18,7 +18,7 @@ export const AddonList = ({handleDownload, install, appList, openPage, openModal
             <tr key={key}>
               <td onClick={() => openPage(app)}>
                 <img
-                  src={app.icons !== null ? 
+                  src={app.icons !== null && app.icons !== undefined ? 
                     `/${location.href.split('/')[3]}/owa/openmrs-addonmanager/${app.icons[48]}` : 
                     `./img/omrs-button.png`}
                   alt="addon logo"


### PR DESCRIPTION
## JIRA TICKET NAME:
AOM-42: [Fix bug in online search for addons](https://issues.openmrs.org/browse/AOM-42)

### SUMMARY:
When a user searches for an app that is not installed and the image icon is not available, the app displays the default OpenMRS image icon.