### PR TITLE
AOM-45: Last column header should be 'Action'

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -369,9 +369,7 @@ export default class ManageApps extends React.Component {
                       <th>Name</th>
                       <th>Developer</th>
                       <th>Version</th>
-                      {this.state.install === false ? 
-                        <th>Delete</th> : 
-                        <th>Install</th>}
+                      <th>Action</th>
                     </tr>
                   </thead>
                   {this.state.appList.length < 1 ? 

--- a/tests/components/ManageAddon.test.js
+++ b/tests/components/ManageAddon.test.js
@@ -40,7 +40,7 @@ describe('<ManageApps />', () => {
         expect(renderedComponent.find("th").getNodes()[3]
             .props.children).to.equal('Version');
         expect(renderedComponent.find("th").getNodes()[4]
-            .props.children).to.equal('Delete');
+            .props.children).to.equal('Action');
     });
 
     it('should mount the AddonList component in itself', () => {


### PR DESCRIPTION
# JIRA TICKET NAME:
AOM-45: [Last column header should be 'Action'](https://issues.openmrs.org/browse/AOM-45)

## SUMMARY:
This PR aims to set the last column header to be 'Action'