### PR TITLE
AOM-46: Close modal pop-up when `Escape` key is pressed

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -58,6 +58,11 @@ export default class ManageApps extends React.Component {
   
   componentDidMount() {
     jQuery("#fileInput").filestyle({btnClass: "btn-primary"});
+    $(document).keydown(e => { 
+      if (e.keyCode == 27) {
+        this.hideModal();
+      } 
+    });
   }
 
   handleApplist() {


### PR DESCRIPTION
# JIRA TICKET NAME:
AOM-46: [Close modal pop-up when `Escape` key is pressed](https://issues.openmrs.org/browse/AOM-46)

## SUMMARY:
This PR aims to support escape key on popups (e.g., when confirming delete action, pressing escape key should dismiss the confirmation dialog)