### PR TITLE
AOM-49: Fix Img error 404 bug

### DIFF
--- a/webpack.sample.config.js
+++ b/webpack.sample.config.js
@@ -142,9 +142,10 @@ plugins.push( new webpack.DefinePlugin({
 }));
 
 plugins.push(new CopyWebpackPlugin([{
-  from: './app/img/omrs-button.png',
-  to: 'img/omrs-button.png'},
-{ 
+  from: './app/img/',
+  to: 'img'
+},
+{
   from: 'libs',
   to: 'libs'
 }]));


### PR DESCRIPTION
# JIRA TICKET NAME:
AOM-49: [Fix Img error 404 bug](https://issues.openmrs.org/browse/AOM-49)

## SUMMARY:
This PR aims to fix the openMRS image 404 bug by adding a path to it in the module bundling file