### PR TITLE
A0M-70: Filter add-on list to only display add-ons with updates

### DIFF
--- a/app/css/openmrs-addonmanager.css
+++ b/app/css/openmrs-addonmanager.css
@@ -315,12 +315,9 @@ legend.scheduler-border {
 }
 
 .install-icon, .view-icon {
-    font-size: 20px;
-    color: #1F78D5;
-}
-
-td {
-    cursor: pointer;
+    font-size: 1.05em;
+    color: #363463;
+    margin-right: 4px;
 }
 
 .close {
@@ -761,4 +758,17 @@ body.loading .waiting-modal {
 .btn-mark-ok {
     background: #5b57a6;
     color: #ffffff;
+}
+.app-details:hover{
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.download-update {
+    color: #3bb300;
+    font-size: 1.1em;
+}
+
+.download-update:hover {
+    cursor: pointer;
 }

--- a/app/js/components/manageApps/AddonList.jsx
+++ b/app/js/components/manageApps/AddonList.jsx
@@ -10,6 +10,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
+import SingleAddon from './SingleAddon.jsx';
 
 export const AddonList = ({
   handleDownload,
@@ -37,73 +38,25 @@ export const AddonList = ({
           let addonParam = app.appDetails.uuid ?
             'module-' + app.appDetails.uuid : 'owa-' + app.appDetails.name;
           return (
-            <tr key={key}>
-              <td onClick={() => openPage(app.appDetails)}>
-                <img
-                  src={app.appDetails &&
-                    app.appDetails.icon !== null &&
-                    app.appDetails.icons !== undefined ?
-                    `/${location.href.split('/')[3]}/owa/openmrs-addonmanager/${app.appDetails.icons[48]}` :
-                    `./img/omrs-button.png`}
-                  alt="addon logo"
+            updatesAvailable?
+              updatesAvailable.hasOwnProperty(app.appDetails.name)?
+                <SingleAddon
+                  app={app}
+                  key={key}
+                  addonParam={addonParam}
+                  updatesVersion={updatesAvailable[app.appDetails.name]}
                 />
-              </td>
-              <td onClick={() => openPage(app.appDetails)}>
-                <div className="addon-name">
-                  {
-                    app.appDetails.started === true || app.appDetails.started === undefined ?
-                      <div className="status-icon" id="started-status" />
-                      :
-                      <div className="status-icon" id="stopped-status" />
-                  }
-                  {app.appDetails && app.appDetails.name}
-                </div>
-                <div><h5 className="addon-description">
-                  {app.appDetails && app.appDetails.description}
-                </h5></div>
-                {updatesAvailable && updatesAvailable.hasOwnProperty(app.appDetails.name) ? <span className="update-notification">New version Available </span>: null}
-                {updatesAvailable && updatesAvailable.hasOwnProperty(app.appDetails.name) ? updatesAvailable[app.appDetails.name]: null}
-
-              </td>
-              <td onClick={() => openPage(app.appDetails)}>
-                {
-                  app.appDetails && app.appDetails.uuid ?
-                    app.appDetails.author :
-                    app.appDetails && app.appDetails.developer ?
-                      app.appDetails.developer.name :
-                      app.appDetails.maintainers[0].name
-                }
-              </td>
-              <td onClick={() => openPage(app.appDetails)}>
-                {app.appDetails.version ?
-                  app.appDetails.version :
-                  app.appDetails.latestVersion}
-              </td>
-              <td
-                className="text-center"
-                id="view-icon-wrapper"
-              >
-                {
-                  app.install === false ?
-                    <Link
-                      to={{
-                        pathname: "addon/" + addonParam,
-                      }}
-                    >
-                      <button id="view-addon-btn" className="btn btn-secondary">
-                        <i className="glyphicon glyphicon-option-vertical view-icon" />
-                        View
-                      </button>
-                    </Link>
-                    :
-                    <i
-                      className="glyphicon glyphicon-download-alt text-primary install-icon"
-                      id="icon-btn"
-                      onClick={(e) => handleDownload(app.downloadUri)(e)}
-                    />
-                }
-              </td>
-            </tr>
+                :
+                null
+              :
+              <SingleAddon
+                app={app}
+                key={key}
+                handleDownload={handleDownload}
+                openPage={openPage}
+                addonParam={addonParam}
+                updatesVersion={null}
+              />
           );
         })
       }

--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -1,4 +1,5 @@
-/* * This Source Code Form is subject to the terms of the Mozilla Public License,
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
@@ -36,7 +37,7 @@ export default class ManageApps extends React.Component {
       files: null,
       displayInvalidZip: false,
       searchComplete: false,
-      updatesAvailable: [],
+      updatesAvailable: null,
       searchedAddons: [],
     };
 
@@ -58,6 +59,7 @@ export default class ManageApps extends React.Component {
     this.handleOmodUploadRequest = this.handleOmodUploadRequest.bind(this);
     this.displayManageOwaButtons = this.displayManageOwaButtons.bind(this);
     this.checkForUpdates = this.checkForUpdates.bind(this);
+    this.clearUpdates = this.clearUpdates.bind(this);
     this.startAllModules = this.startAllModules.bind(this);
     this.getInstalled = this.getInstalled.bind(this);
   }
@@ -101,7 +103,7 @@ export default class ManageApps extends React.Component {
       (error) => {
         toastr.error(error);
       }
-    );
+      );
   }
 
   handleDrop(files) {
@@ -455,6 +457,9 @@ export default class ManageApps extends React.Component {
   }
 
   checkForUpdates() {
+    this.setState({
+      searchComplete: false
+    });
     const installedAddons = this.state.appList;
     const updatesAvailable = {};
     axios.get(`https://addons.openmrs.org/api/v1/addon`).then((response) => {
@@ -462,7 +467,7 @@ export default class ManageApps extends React.Component {
         response.data.forEach((result) => {
           if (addon.appDetails.name === result.name) {
             result.latestVersion > addon.appDetails.version ?
-              updatesAvailable[addon.appDetails.name] = result.latestVersion
+              updatesAvailable[addon.appDetails.name] = { version: result.latestVersion, uid: result.uid }
               :
               null
             return;
@@ -470,12 +475,25 @@ export default class ManageApps extends React.Component {
         });
       });
 
-      this.setState({ updatesAvailable });
+      this.setState({ 
+        updatesAvailable,
+        searchComplete: true,
+       });
     }).catch(
       (error) => {
         toastr.error(error);
       }
     );
+  }
+
+  clearUpdates(){
+    this.setState({
+      searchComplete: false
+    });
+    this.setState({ 
+      updatesAvailable: null,
+      searchComplete: true
+    });
   }
 
   onlineSearchHandler(searchValue) {
@@ -609,7 +627,9 @@ export default class ManageApps extends React.Component {
             <div className="col-sm-12">
               <h2 className="manage-addon-title">Add-on Manager</h2>
               <span className="pull-right manage-settings-wrapper">
-                <button className="button" onClick={this.checkForUpdates}>Check For Updates</button>
+                <span id="startall-modules-btn"
+                  className="btn btn-secondary" 
+                  onClick={updatesAvailable? this.clearUpdates : this.checkForUpdates}>{updatesAvailable? 'Back to all Addons': 'Check For Updates'}</span>
                 <span
                   id="startall-modules-btn"
                   className="btn btn-secondary"

--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import axios from 'axios';
+import { Link } from 'react-router';
+
+export default class SingleAddon extends React.Component{
+    constructor(props){
+        super(props);
+        this.getUpdate = this.getUpdate.bind(this);
+    }
+
+    getUpdate(e, uid){
+        e.preventDefault();
+        axios.get(`https://addons.openmrs.org/api/v1//addon/${uid}`)
+            .then(response => {
+                response.data.versions[0].downloadUri?
+                    location.href = response.data.versions[0].downloadUri
+                    :
+                    null
+            }).catch((error) =>{
+                toastr.error(error);
+            })
+    }
+
+    render(){
+        const {
+            app,
+            key,
+            addonParam,
+            updatesVersion,
+            handleDownload,
+            openPage
+        } = this.props
+
+        return(
+            <tr key={key}>
+                <td>
+                    <img
+                    src={app.appDetails &&
+                        app.appDetails.icon !== null &&
+                        app.appDetails.icons !== undefined ?
+                        `/${location.href.split('/')[3]}/owa/openmrs-addonmanager/${app.appDetails.icons[48]}` :
+                        `./img/omrs-button.png`}
+                    alt="addon logo"
+                    />
+                </td>
+                <td>
+                    <div className="addon-name">
+                        {
+                            app.appDetails.started === true || app.appDetails.started === undefined ?
+                            <div className="status-icon" id="started-status" />
+                            :
+                            <div className="status-icon" id="stopped-status" />
+                        }
+                        {app.appDetails.started === true || app.appDetails.started === false ?
+                            app.appDetails && app.appDetails.name
+                            :
+                            <span className="app-details" onClick={() => openPage(app.appDetails)}>{app.appDetails && app.appDetails.name}</span>
+                        }
+                    </div>
+                    <div><h5 className="addon-description">
+                    {app.appDetails && app.appDetails.description}
+                    </h5></div>
+                    {updatesVersion ? <span className="update-notification">New version Available {updatesVersion.version} </span>: null}
+                    {updatesVersion ? <span className="glyphicon glyphicon-download-alt download-update" onClick={(e) => this.getUpdate(e, updatesVersion.uid)}></span>: null}
+                </td>
+                <td>
+                    {
+                    app.appDetails && app.appDetails.uuid ?
+                        app.appDetails.author :
+                        app.appDetails && app.appDetails.developer ?
+                        app.appDetails.developer.name :
+                        app.appDetails.maintainers[0].name
+                    }
+                </td>
+                <td>
+                    {app.appDetails.version ?
+                    app.appDetails.version :
+                    app.appDetails.latestVersion}
+                </td>
+                <td
+                    className="text-center"
+                    id="view-icon-wrapper"
+                >
+                    {
+                    app.install === false ?
+                        <Link
+                        to={{
+                            pathname: "addon/" + addonParam,
+                        }}
+                        >
+                        <button id="view-addon-btn" className="btn btn-secondary">
+                            <i className="glyphicon glyphicon-expand view-icon" />
+                            View
+                        </button>
+                        </Link>
+                        :
+                        <i
+                        className="glyphicon glyphicon-download-alt text-primary install-icon"
+                        id="icon-btn"
+                        onClick={(e) => handleDownload(app.downloadUri)(e)}
+                        />
+                    }
+                </td>
+            </tr>
+        );
+    }
+}


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-70 Filter add-on list to only display add-ons with updates](https://issues.openmrs.org/browse/AOM-70)

### SUMMARY:
Upon clicking the check for updates button, the add-on list is filtered such that only add-ons with updates are displayed ignoring all the others without updates.

