### PR TITLE
AOM-72: Add icon to indicate that add-on is running

### DIFF
--- a/app/css/openmrs-addonmanager.css
+++ b/app/css/openmrs-addonmanager.css
@@ -298,6 +298,8 @@ legend.scheduler-border {
 
 .addon-name {
     font-weight: bold;
+    display: flex;
+    flex-direction: row;
 }
 
 .addon-description {
@@ -656,10 +658,6 @@ body.loading .waiting-modal {
     margin-left: 20px;
 }
 
-#addon-name {
-    display: inline;
-}
-
 #addon-description {
     padding-top: 1%;
 }
@@ -672,8 +670,8 @@ body.loading .waiting-modal {
 .status-icon {
     margin-right: 12px;
     border-radius: 50%;
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
 }
 
 #started-status {

--- a/app/js/components/manageApps/AddonList.jsx
+++ b/app/js/components/manageApps/AddonList.jsx
@@ -30,7 +30,15 @@ export const AddonList = ({ handleDownload, appList, openPage, openModal, update
                 />
               </td>
               <td onClick={() => openPage(app.appDetails)}>
-                <div className="addon-name">{app.appDetails && app.appDetails.name}</div>
+                <div className="addon-name">
+                  {
+                    app.appDetails.started === true || app.appDetails.started === undefined ?
+                      <div className="status-icon" id="started-status" />
+                      :
+                      <div className="status-icon" id="stopped-status" />
+                  }
+                  {app.appDetails && app.appDetails.name}
+                </div>
                 <div><h5 className="addon-description">
                   {app.appDetails && app.appDetails.description}
                 </h5></div>

--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -94,6 +94,7 @@ export default class ManageApps extends React.Component {
         showMsg: true,
         searchComplete: true,
       });
+      this.handleApplist();
     }).catch(
       (error) => {
         toastr.error(error);

--- a/tests/components/AddonList.test.js
+++ b/tests/components/AddonList.test.js
@@ -40,21 +40,21 @@ describe('<AddonList />', () => {
     const openPage = () => {};
     const openModal = () => {};
     const addonList = mount( <AddonList appList={appList} openPage={openPage}  openModal={openModal}/ > );
-    
+
     it('should render a tbody', () => {
         expect(addonList.find("tbody")).to.have.length(1);
     });
-    
+
     it('should render a tr tag', () => {
         expect(addonList.find("tr")).to.have.length(1);
     });
-    
+
     it('should render td tag', () => {
         expect(addonList.find("td")).to.have.length(5);
     });
-    
+
     it('should render div tags', () => {
-        expect(addonList.find("div")).to.have.length(2);
+        expect(addonList.find("div")).to.have.length(3);
     });
 
     it('should render a h2 tag', () => {


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-72 Add icon to indicate that add-on is running](https://issues.openmrs.org/browse/AOM-72)
### SUMMARY:
Add icons on the index page of add-on manager to indicate which add-ons are running and which one are not