### PR TITLE
AOM-77: Only display download button for addons yet to be installed

### DIFF
--- a/app/js/components/manageApps/AddonList.jsx
+++ b/app/js/components/manageApps/AddonList.jsx
@@ -8,13 +8,32 @@
  * graphic logo is a trademark of OpenMRS Inc.
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
-export const AddonList = ({ handleDownload, appList, openPage, openModal, updatesAvailable }) => {
+export const AddonList = ({
+  handleDownload,
+  addonList,
+  openPage,
+  openModal,
+  updatesAvailable,
+  searchedAddons,
+  getInstalled,
+}) => {
+  let installedSearchResults;
+  const appList =  searchedAddons.length > 0 ? searchedAddons : addonList;
+  searchedAddons.length > 0 ? installedSearchResults = getInstalled(addonList, searchedAddons) : null;
+
   return (
     <tbody>
       {
         appList.map((app, key) => {
+          let found = null;
+          searchedAddons.length > 0 && installedSearchResults.includes(app.appDetails.name) ?
+            found = addonList.find(addon => addon.appDetails.name === app.appDetails.name) : null;
+          if (found) {
+            app = found;
+          }
           let addonParam = app.appDetails.uuid ?
             'module-' + app.appDetails.uuid : 'owa-' + app.appDetails.name;
           return (
@@ -93,8 +112,10 @@ export const AddonList = ({ handleDownload, appList, openPage, openModal, update
 };
 
 AddonList.propTypes = {
-  handleDownload: React.PropTypes.func.isRequired,
-  appList: React.PropTypes.array.isRequired,
-  openPage: React.PropTypes.func.isRequired,
-  openModal: React.PropTypes.func.isRequired
+  addonList: PropTypes.array.isRequired,
+  openPage: PropTypes.func.isRequired,
+  openModal: PropTypes.func.isRequired,
+  handleDownload: PropTypes.func.isRequired,
+  searchedAddons: PropTypes.array.isRequired,
+  getInstalled: PropTypes.func.isRequired,
 };

--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -37,6 +37,7 @@ export default class ManageApps extends React.Component {
       displayInvalidZip: false,
       searchComplete: false,
       updatesAvailable: [],
+      searchedAddons: [],
     };
 
     this.apiHelper = new ApiHelper(null);
@@ -58,6 +59,7 @@ export default class ManageApps extends React.Component {
     this.displayManageOwaButtons = this.displayManageOwaButtons.bind(this);
     this.checkForUpdates = this.checkForUpdates.bind(this);
     this.startAllModules = this.startAllModules.bind(this);
+    this.getInstalled = this.getInstalled.bind(this);
   }
 
   componentWillMount() {
@@ -487,6 +489,7 @@ export default class ManageApps extends React.Component {
           if (searchResults.length === 0) {
             this.setState({
               appList: [],
+              searchedAddons: [],
               searchComplete: true
             });
           } else {
@@ -503,25 +506,37 @@ export default class ManageApps extends React.Component {
                 if (index === searchResults.length - 1) {
                   this.setState((prevState, props) => {
                     return {
-                      appList: resultData,
+                      searchedAddons: resultData,
                       searchComplete: true
                     };
                   });
                 }
               }))
               .catch(error => {
-                if (error) this.setState({ appList: [], searchComplete: true });
+                if (error) {
+                  this.setState({
+                    appList: [],
+                    searchedAddons: [],
+                    searchComplete: true,
+                  });}
               });
           }
         })
         .catch(error => {
-          if (error) this.setState({ appList: [], searchComplete: true });
+          if (error) {
+            this.setState({
+              appList: [],
+              searchedAddons: [],
+              searchComplete: true,
+            });
+          }
         });
     } else {
       this.setState((prevState, props) => {
         return {
           appList: staticAppList,
-          searchComplete: true
+          searchedAddons: [],
+          searchComplete: true,
         };
       });
     }
@@ -543,6 +558,19 @@ export default class ManageApps extends React.Component {
     }
   }
 
+  getInstalled(appList, searchedAddons) {
+    const installedSearchResults = [];
+    const installedNames = appList.map((app) => {
+      return app.appDetails.name;
+    });
+    searchedAddons.forEach((addon) => {
+      installedNames.includes(addon.appDetails.name) ?
+        installedSearchResults.push(addon.appDetails.name)
+        : null;
+    });
+    return installedSearchResults;
+  }
+
   render() {
     const {
       files,
@@ -553,6 +581,7 @@ export default class ManageApps extends React.Component {
       msgType,
       msgBody,
       appList,
+      searchedAddons,
       isOpen,
       selectedApp,
       searchComplete,
@@ -640,11 +669,13 @@ export default class ManageApps extends React.Component {
                         </tr>
                       </tbody> :
                       <AddonList
-                        handleDownload={this.handleDownload}
-                        appList={appList}
+                        addonList={appList}
+                        searchedAddons={searchedAddons}
                         updatesAvailable={updatesAvailable}
                         openPage={this.openPage}
                         openModal={this.openModal}
+                        handleDownload={this.handleDownload}
+                        getInstalled={this.getInstalled}
                       />
                     }
                   </table>
@@ -661,9 +692,9 @@ export default class ManageApps extends React.Component {
           </div>
         </div>
         {disableUploadElements &&
-            <div className="waiting-modal">
-              <p className="upload-text">Uploading {uploadStatus}%</p>
-            </div>}
+          <div className="waiting-modal">
+            <p className="upload-text">Uploading {uploadStatus}%</p>
+          </div>}
       </div>
     );
   }

--- a/tests/components/AddonList.test.js
+++ b/tests/components/AddonList.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
-import  { AddonList }  from '../../app/js/components/manageApps/AddonList.jsx';
+import { AddonList } from '../../app/js/components/manageApps/AddonList.jsx';
 
 
 describe('<AddonList />', () => {
@@ -37,31 +37,42 @@ describe('<AddonList />', () => {
         install: false
     }];
 
-    const openPage = () => {};
-    const openModal = () => {};
-    const addonList = mount( <AddonList appList={appList} openPage={openPage}  openModal={openModal}/ > );
+    const addonList = [];
+    const searchedAddons = [];
+    const openPage = () => { };
+    const openModal = () => { };
+    const handleDownload = () => { };
+    const getInstalled = () => { };
+    const testAddonList = mount(
+        <AddonList
+            addonList={appList}
+            searchedAddons={searchedAddons}
+            openPage={openPage}
+            openModal={openModal}
+            handleDownload={handleDownload}
+            getInstalled={getInstalled} />);
 
     it('should render a tbody', () => {
-        expect(addonList.find("tbody")).to.have.length(1);
+        expect(testAddonList.find("tbody")).to.have.length(1);
     });
 
     it('should render a tr tag', () => {
-        expect(addonList.find("tr")).to.have.length(1);
+        expect(testAddonList.find("tr")).to.have.length(1);
     });
 
     it('should render td tag', () => {
-        expect(addonList.find("td")).to.have.length(5);
+        expect(testAddonList.find("td")).to.have.length(5);
     });
 
     it('should render div tags', () => {
-        expect(addonList.find("div")).to.have.length(3);
+        expect(testAddonList.find("div")).to.have.length(3);
     });
 
     it('should render a h2 tag', () => {
-        expect(addonList.find("h5")).to.have.length(1);
+        expect(testAddonList.find("h5")).to.have.length(1);
     });
 
     it('should render a image tag', () => {
-        expect(addonList.find("img")).to.have.length(1);
+        expect(testAddonList.find("img")).to.have.length(1);
     });
 });


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-77 On search, only display the download buttons for add-ons that are yet to be installed](https://issues.openmrs.org/browse/AOM-77)

### SUMMARY:
When a user searches the add-on index, the results displayed should only have the download action for add-ons that have not been installed and retain the view button for installed add-ons.


@kodero