### PR TITLE
AOM-80: Add-on list only displays installed OWAs after installing an OWA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ libs
 package-lock.json
 # Vscode autogen folders
 .vscode/
+.idea

--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -329,10 +329,9 @@ export default class ManageApps extends React.Component {
                 showMsg: true,
                 msgBody: `${fileName} has been successfully installed`,
                 msgType: "success",
-                appList: resultData,
-                staticAppList: resultData,
               };
             });
+            this.handleApplist();
           }
         });
       }.bind(this),


### PR DESCRIPTION
## JIRA TICKET NAME:

[AOM-80: Add-on list only displays installed OWAs after installing an OWA](https://issues.openmrs.org/browse/AOM-80)

### SUMMARY:

Instead of showing all installed add-ons, only installed OWAs are displayed after OWA installation is complete.

