### PR TITLE
AOM 82: Add-on list should display all add-ons after an add-on has been installed

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -278,8 +278,10 @@ export default class ManageApps extends React.Component {
           uploadStatus: 0,
           showProgress: false,
           files: null,
+          updatesAvailable: null,
         };
       });
+      this.handleApplist();
     }).catch((error) => {
       toastr.error(error);
     });
@@ -329,6 +331,7 @@ export default class ManageApps extends React.Component {
                 showMsg: true,
                 msgBody: `${fileName} has been successfully installed`,
                 msgType: "success",
+                updatesAvailable: null,
               };
             });
             this.handleApplist();


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-82: Add-on list should display all add-ons after an add-on has been installed](https://issues.openmrs.org/browse/AOM-82)
### SUMMARY:
After one has clicked on check for updates and the add-on list only displays add-ons with available updates, if one then installs an add-on, it does not list all installed Add-ons once installation is done as it should.