### PR TITLE
Notify user that a module does not have a UI

### DIFF
--- a/app/css/openmrs-addonmanager.css
+++ b/app/css/openmrs-addonmanager.css
@@ -781,3 +781,7 @@ body.loading .waiting-modal {
 .btn-lower-margin {
     margin-bottom: 30px;
 }
+
+.module-cursor {
+  cursor: pointer
+}

--- a/app/js/components/manageApps/AddonList.jsx
+++ b/app/js/components/manageApps/AddonList.jsx
@@ -16,6 +16,7 @@ export const AddonList = ({
   handleDownload,
   addonList,
   openPage,
+  handleAlert,
   openModal,
   updatesAvailable,
   searchedAddons,
@@ -43,6 +44,7 @@ export const AddonList = ({
                 <SingleAddon
                   app={app}
                   key={key}
+                  handleAlert={handleAlert}
                   addonParam={addonParam}
                   updatesVersion={updatesAvailable[app.appDetails.name]}
                 />
@@ -53,6 +55,7 @@ export const AddonList = ({
                 app={app}
                 key={key}
                 handleDownload={handleDownload}
+                handleAlert={handleAlert}
                 openPage={openPage}
                 addonParam={addonParam}
                 updatesVersion={null}

--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -17,6 +17,7 @@ import BreadCrumbComponent from '../breadCrumb/BreadCrumbComponent.jsx';
 import { ApiHelper } from '../../helpers/apiHelper';
 import { AddonList } from './AddonList.jsx';
 import InvalidZipUploadModal from './InvalidZipUploadModal.jsx';
+import ModuleClickAlert from './ModuleClickModal.jsx';
 import Utility from './../../utility';
 
 export default class ManageApps extends React.Component {
@@ -31,6 +32,7 @@ export default class ManageApps extends React.Component {
       uploadStatus: 0,
       showProgress: false,
       isOpen: false,
+      isOpenAlert : false,
       selectedApp: null,
       downloadUri: null,
       addonAlreadyInstalled: null,
@@ -45,6 +47,7 @@ export default class ManageApps extends React.Component {
     this.alertMessage = '';
     this.openPage = this.openPage.bind(this);
     this.openModal = this.openModal.bind(this);
+    this.handleAlert = this.handleAlert.bind(this);
     this.hideModal = this.hideModal.bind(this);
     this.handleDrop = this.handleDrop.bind(this);
     this.handleClear = this.handleClear.bind(this);
@@ -427,6 +430,13 @@ export default class ManageApps extends React.Component {
     });
   }
 
+
+  handleAlert(){
+    this.setState({
+      isOpenAlert : !this.state.isOpenAlert
+    })
+  }
+
   openModal(app) {
     return (e) => {
       this.setState((prevState, props) => {
@@ -603,6 +613,7 @@ export default class ManageApps extends React.Component {
       appList,
       searchedAddons,
       isOpen,
+      isOpenAlert,
       selectedApp,
       searchComplete,
       displayInvalidZip } = this.state;
@@ -694,6 +705,7 @@ export default class ManageApps extends React.Component {
                         addonList={appList}
                         searchedAddons={searchedAddons}
                         updatesAvailable={updatesAvailable}
+                        handleAlert={this.handleAlert}
                         openPage={this.openPage}
                         openModal={this.openModal}
                         handleDownload={this.handleDownload}
@@ -701,6 +713,10 @@ export default class ManageApps extends React.Component {
                       />
                     }
                   </table>
+                  <ModuleClickAlert
+                    isOpenAlert={isOpenAlert}
+                    handleAlert={this.handleAlert}
+                  />
                 </Loader>
                 {
                   displayInvalidZip && (

--- a/app/js/components/manageApps/ModuleClickModal.jsx
+++ b/app/js/components/manageApps/ModuleClickModal.jsx
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import {
+  Modal,
+  ModalHeader,
+  ModalTitle,
+  ModalClose,
+  ModalBody,
+  ModalFooter } from 'react-modal-bootstrap';
+
+const ModuleClickAlert = ({ isOpenAlert, handleAlert }) => {
+  return (
+    <Modal isOpen={isOpenAlert} onRequestHide={handleAlert}>
+      <ModalHeader>
+        <ModalClose onClick={handleAlert}/>
+        <ModalTitle >
+          <span id="msg-modal-title" >
+            Could not redirect
+          </span>
+        </ModalTitle>
+      </ModalHeader>
+      <ModalBody>
+        <p>Sorry, you clicked a module which does not have a user interface</p>
+      </ModalBody>
+      <ModalFooter>
+        <button className="btn btn-default btn-mark-ok" onClick={handleAlert}>OK</button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default ModuleClickAlert;
+
+ModuleClickAlert.propTypes = {
+  isOpenAlert: React.PropTypes.bool.isRequired,
+  handleAlert: React.PropTypes.func.isRequired
+};

--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -26,6 +26,7 @@ export default class SingleAddon extends React.Component{
       app,
       key,
       addonParam,
+      handleAlert,
       updatesVersion,
       handleDownload,
       openPage
@@ -52,7 +53,7 @@ export default class SingleAddon extends React.Component{
                 <div className="status-icon" id="stopped-status" />
             }
             {app.appDetails.started === true || app.appDetails.started === false ?
-              app.appDetails && app.appDetails.name
+              <span className="module-cursor" onClick={() => handleAlert()}> { app.appDetails && app.appDetails.name }</span>
               :
               <span className="app-details" onClick={() => openPage(app.appDetails)}>{app.appDetails && app.appDetails.name}</span>
             }


### PR DESCRIPTION
## JIRA TICKET NAME:

[AOM-84:  Notify user that a module does not have a UI](https://issues.openmrs.org/browse/AOM-84)

### SUMMARY:
#### Currently :    
When you click on an OWA it will redirect to the user interface, but when you click on a module it doesn't redirect since the modules don't have user interfaces. It also doesn't give the user a warning that the module can't redirect.
#### After the Fix:
When the user clicks on a module a modal will pop up alerting the user that a module can't redirect.


