### PR TITLE
AOM-84: Notify user that a module does not have a UI

### DIFF
--- a/app/css/openmrs-addonmanager.css
+++ b/app/css/openmrs-addonmanager.css
@@ -781,3 +781,7 @@ body.loading .waiting-modal {
 .btn-lower-margin {
     margin-bottom: 30px;
 }
+
+.module-click-cursor {
+    cursor: pointer;
+}

--- a/app/js/components/manageApps/AddonList.jsx
+++ b/app/js/components/manageApps/AddonList.jsx
@@ -17,6 +17,7 @@ export const AddonList = ({
   addonList,
   openPage,
   openModal,
+  handleUserClick,
   updatesAvailable,
   searchedAddons,
   getInstalled,
@@ -44,6 +45,7 @@ export const AddonList = ({
                   app={app}
                   key={key}
                   addonParam={addonParam}
+                  handleUserClick={handleUserClick}
                   updatesVersion={updatesAvailable[app.appDetails.name]}
                 />
                 :
@@ -52,6 +54,7 @@ export const AddonList = ({
               <SingleAddon
                 app={app}
                 key={key}
+                handleUserClick={handleUserClick}
                 handleDownload={handleDownload}
                 openPage={openPage}
                 addonParam={addonParam}
@@ -67,6 +70,7 @@ export const AddonList = ({
 AddonList.propTypes = {
   addonList: PropTypes.array.isRequired,
   openPage: PropTypes.func.isRequired,
+  handleUserClick: PropTypes.func.isRequired,
   openModal: PropTypes.func.isRequired,
   handleDownload: PropTypes.func.isRequired,
   searchedAddons: PropTypes.array.isRequired,

--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -46,6 +46,7 @@ export default class ManageApps extends React.Component {
     this.openPage = this.openPage.bind(this);
     this.openModal = this.openModal.bind(this);
     this.hideModal = this.hideModal.bind(this);
+    this.handleUserClick = this.handleUserClick.bind(this);
     this.handleDrop = this.handleDrop.bind(this);
     this.handleClear = this.handleClear.bind(this);
     this.handleUpload = this.handleUpload.bind(this);
@@ -287,6 +288,10 @@ export default class ManageApps extends React.Component {
     });
   }
 
+  handleUserClick(name){
+    toastr.info(`Sorry, there is no open web app for ${name}`);
+  }
+
   handleUploadRequest() {
     const resultData = [];
     const applicationDistribution = location.href.split('/')[2];
@@ -477,7 +482,7 @@ export default class ManageApps extends React.Component {
         });
       });
 
-      this.setState({ 
+      this.setState({
         updatesAvailable,
         searchComplete: true,
        });
@@ -492,7 +497,7 @@ export default class ManageApps extends React.Component {
     this.setState({
       searchComplete: false
     });
-    this.setState({ 
+    this.setState({
       updatesAvailable: null,
       searchComplete: true
     });
@@ -630,7 +635,7 @@ export default class ManageApps extends React.Component {
               <h2 className="manage-addon-title">Add-on Manager</h2>
               <span className="pull-right manage-settings-wrapper">
                 <span id="startall-modules-btn"
-                  className="btn btn-secondary" 
+                  className="btn btn-secondary"
                   onClick={updatesAvailable? this.clearUpdates : this.checkForUpdates}>{updatesAvailable? 'Back to all Addons': 'Check For Updates'}</span>
                 <span
                   id="startall-modules-btn"
@@ -693,6 +698,7 @@ export default class ManageApps extends React.Component {
                       <AddonList
                         addonList={appList}
                         searchedAddons={searchedAddons}
+                        handleUserClick={this.handleUserClick}
                         updatesAvailable={updatesAvailable}
                         openPage={this.openPage}
                         openModal={this.openModal}

--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -27,6 +27,7 @@ export default class SingleAddon extends React.Component{
       key,
       addonParam,
       updatesVersion,
+      handleUserClick,
       handleDownload,
       openPage
     } = this.props;
@@ -52,9 +53,17 @@ export default class SingleAddon extends React.Component{
                 <div className="status-icon" id="stopped-status" />
             }
             {app.appDetails.started === true || app.appDetails.started === false ?
-              app.appDetails && app.appDetails.name
+              <span
+                className="module-click-cursor"
+                onClick={() => handleUserClick(app.appDetails.name)}>
+                {app.appDetails && app.appDetails.name}
+              </span>
               :
-              <span className="app-details" onClick={() => openPage(app.appDetails)}>{app.appDetails && app.appDetails.name}</span>
+              <span
+                className="app-details"
+                onClick={() => openPage(app.appDetails)}>
+                {app.appDetails && app.appDetails.name}
+              </span>
             }
           </div>
           <div><h5 className="addon-description">


### PR DESCRIPTION


## JIRA TICKET NAME:
[AOM-84: Notify user that a module does not have a UI](https://issues.openmrs.org/browse/AOM-84)

### SUMMARY:
#### Currently :    
When you click on an OWA it will redirect to the user interface, but when you click on a module it doesn't redirect since the modules don't have user interfaces. It also doesn't give the user a warning that the module can't redirect.

#### After fix:
When a user clicks on a module name a toast pops up telling the user the module can't redirect.
