### PR TITLE
AOM-60: Enable installation of open web apps

### DIFF
--- a/app/css/openmrs-addonmanager.css
+++ b/app/css/openmrs-addonmanager.css
@@ -801,3 +801,7 @@ body.loading .waiting-modal {
 .module-click-cursor {
     cursor: pointer;
 }
+
+.install {
+    margin-top: 5px 
+}


### PR DESCRIPTION
## JIRA TICKET NAME: [Enable installation of open web apps](https://issues.openmrs.org/browse/AOM-60)

### SUMMARY:
Previously open web apps were installed by downloading the zip file to the file system, then re-uploading this back to install it. This PR aims to solve this by merging this two actions into one by the click of the install button on the client
