### PR TITLE
AOM-93: Remove status icon from add-on search results

### DIFF
--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -50,10 +50,12 @@ export default class SingleAddon extends React.Component{
         <td>
           <div className="addon-name">
             {
+              !app.install ?
               app.appDetails.started === true || app.appDetails.started === undefined ?
                 <div className="status-icon" id="started-status" />
                 :
                 <div className="status-icon" id="stopped-status" />
+                : null
             }
             {app.appDetails.started === true || app.appDetails.started === false ?
               <span


### PR DESCRIPTION
## JIRA TICKET NAME: [AOM-93 Remove status icon from add-on search results](https://issues.openmrs.org/browse/AOM-93)

### SUMMARY:
Presently, when you search for an add-on, the list of add-ons returned from the search results, displays the status icon of the add-on, this ticket removes the status icon from the search result.