### PR TITLE
AOM-61: Enable installation or upgrading of a module by clicking on a button

### DIFF
--- a/app/css/openmrs-addonmanager.css
+++ b/app/css/openmrs-addonmanager.css
@@ -483,7 +483,7 @@ span.title.breadcrumb-item {
     padding: 2px 5px;
 }
 
-#success-btn, #cancel-btn, #icon-btn, #setting-icon-btn, #view-addon-btn {
+#success-btn, #cancel-btn, #icon-btn, #setting-icon-btn, #view-addon-btn, #install-addon-btn {
     line-height: 1.2em;
     color: white;
     cursor: pointer;
@@ -494,7 +494,7 @@ span.title.breadcrumb-item {
     border-radius: 3px;
 }
 
-#icon-btn, #setting-icon-btn, #startall-modules-btn {
+#icon-btn, #setting-icon-btn, #startall-modules-btn, #upgrade-btn {
     background-color: #dddddd;
     border: #dddddd 1px solid;
     display: inline-block;
@@ -505,11 +505,19 @@ span.title.breadcrumb-item {
     background: -webkit-linear-gradient(top, #ffffff, #dddddd);
 }
 
-#startall-modules-btn {
+#startall-modules-btn, #upgrade-btn {
     padding-top: 4px;
     padding-bottom: 4px;
     margin-bottom: 10px;
     margin-left: 12px;
+    font-weight: bold;
+}
+
+#upgrade-btn {
+    color: #3bb300;
+}
+
+.embolden {
     font-weight: bold;
 }
 
@@ -626,7 +634,7 @@ body.loading .waiting-modal {
     border: 5px solid #ff8080;
 }
 
-#view-addon-btn {
+#view-addon-btn, #install-addon-btn {
     background: -webkit-linear-gradient(top, #ffffff, #dddddd);
     color: #363463;
     font-size: 1.05em;
@@ -701,9 +709,17 @@ body.loading .waiting-modal {
     text-decoration-color: red;
 }
 
-.update-notification {
+.update-notification, .download-link, .download-link:hover {
     color:#3bb300;
     font-size: 0.9em;
+}
+
+.download-link:hover {
+    text-decoration: underline;
+}
+
+#install-addon-btn {
+    color:#3bb300;
 }
 
 .dependency-alert{

--- a/app/js/components/manageApps/AddonList.jsx
+++ b/app/js/components/manageApps/AddonList.jsx
@@ -20,6 +20,8 @@ export const AddonList = ({
   updatesAvailable,
   searchedAddons,
   getInstalled,
+  handleInstall,
+  handleUpgrade,
 }) => {
   let installedSearchResults;
   const appList =  searchedAddons.length > 0 ? searchedAddons : addonList;
@@ -45,6 +47,7 @@ export const AddonList = ({
                   key={key}
                   addonParam={addonParam}
                   updatesVersion={updatesAvailable[app.appDetails.name]}
+                  handleUpgrade={handleUpgrade}
                 />
                 :
                 null
@@ -56,6 +59,7 @@ export const AddonList = ({
                 openPage={openPage}
                 addonParam={addonParam}
                 updatesVersion={null}
+                handleInstall={handleInstall}
               />
           );
         })
@@ -71,4 +75,6 @@ AddonList.propTypes = {
   handleDownload: PropTypes.func.isRequired,
   searchedAddons: PropTypes.array.isRequired,
   getInstalled: PropTypes.func.isRequired,
+  handleInstall: PropTypes.func.isRequired,
+  handleUpgrade: PropTypes.func.isRequired,
 };

--- a/app/js/components/manageApps/ConfirmationModal.jsx
+++ b/app/js/components/manageApps/ConfirmationModal.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Modal,
+  ModalHeader,
+  ModalTitle,
+  ModalClose,
+  ModalBody,
+  ModalFooter
+} from 'react-modal-bootstrap';
+
+export const ConfirmationModal = ({
+  isOpen,
+  upgradeVersion,
+  confirmUpgrade,
+  dismissUpgradeModal,
+  addon,
+}) => {
+
+  return (
+    <Modal isOpen={isOpen} onRequestHide={dismissUpgradeModal}>
+      <ModalHeader>
+        <ModalClose onClick={dismissUpgradeModal} />
+        <ModalTitle>
+          <span className="embolden">
+            Upgrade Confirmation
+          </span>
+        </ModalTitle>
+      </ModalHeader>
+      <ModalBody>
+        <p>Confirm upgrade of
+          <span className="embolden"> {addon && addon.appDetails.name} </span>
+          from version
+          <span className="embolden"> {addon && addon.appDetails.version} </span>
+          to
+          <span className="embolden"> {upgradeVersion} </span>
+        </p>
+      </ModalBody>
+      <ModalFooter>
+        <button
+          className="btn btn-default btn-mark-ok"
+          onClick={confirmUpgrade}>
+          Confirm
+        </button>
+        <button
+          className="btn btn-default btn-mark-ok"
+          onClick={dismissUpgradeModal}>
+          Cancel
+        </button>
+      </ModalFooter>
+    </Modal>
+  );
+}
+
+ConfirmationModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  addon: PropTypes.object.isRequired,
+  message: PropTypes.string.isRequired,
+  upgradeVersion: PropTypes.string.isRequired,
+  confirmUpgrade: PropTypes.func.isRequired,
+  dismissUpgradeModal: PropTypes.func.isRequired,
+};

--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -13,6 +13,7 @@ import JSZip from 'jszip';
 import Loader from 'react-loader';
 import { Router, Route, Link, IndexRoute, hashHistory, browserHistory } from 'react-router';
 import AddAddon from '../manageApps/AddAddon.jsx';
+import { ConfirmationModal } from './ConfirmationModal.jsx';
 import BreadCrumbComponent from '../breadCrumb/BreadCrumbComponent.jsx';
 import { ApiHelper } from '../../helpers/apiHelper';
 import { AddonList } from './AddonList.jsx';
@@ -39,6 +40,12 @@ export default class ManageApps extends React.Component {
       searchComplete: false,
       updatesAvailable: null,
       searchedAddons: [],
+      progressMsg: null,
+      upgrading: false,
+      upgradeAddon: null,
+      upgradeVersion: null,
+      newAddon: null,
+      openUpgradeConfirmation: false,
     };
 
     this.apiHelper = new ApiHelper(null);
@@ -50,6 +57,10 @@ export default class ManageApps extends React.Component {
     this.handleClear = this.handleClear.bind(this);
     this.handleUpload = this.handleUpload.bind(this);
     this.handleDownload = this.handleDownload.bind(this);
+    this.handleInstall = this.handleInstall.bind(this);
+    this.handleUpgrade = this.handleUpgrade.bind(this);
+    this.confirmUpgrade = this.confirmUpgrade.bind(this);
+    this.dismissUpgradeModal = this.dismissUpgradeModal.bind(this);
     this.handleProgress = this.handleProgress.bind(this);
     this.onlineSearchHandler = this.onlineSearchHandler.bind(this);
     this.handleUploadRequest = this.handleUploadRequest.bind(this);
@@ -130,7 +141,8 @@ export default class ManageApps extends React.Component {
         installedOwas.push({
           appDetails: data,
           appType: 'owa',
-          install: false
+          install: false,
+          upgrading: false,
         });
       });
     }).then(() => {
@@ -458,6 +470,89 @@ export default class ManageApps extends React.Component {
     };
   }
 
+  handleUpgrade(addon, newVersion, addonUid) {
+    this.setState({
+      openUpgradeConfirmation: true,
+      upgradeAddon: addon,
+      upgradeVersion: newVersion,
+      upgrading: true,
+    });
+
+    axios.get(`https://addons.openmrs.org/api/v1//addon/${addonUid}`)
+      .then(response => {
+        const newAddon = {
+          appDetails: response.data,
+          downloadUri: response.data.versions[0].downloadUri,
+        }
+        this.setState({ newAddon });
+      }).catch((error) => {
+        toastr.error(error);
+      });
+  }
+
+  handleInstall(addon) {
+    let addonProcess = this.state.upgrading ? 'Upgrading': 'Installing';
+    this.setState({
+      progressMsg: `${addonProcess} ${addon.appDetails.name}`,
+    });
+
+    if (addon && addon.appDetails.type === 'OMOD') {
+      const applicationDistribution = location.href.split('/')[2];
+      const urlPrefix = location.href.substr(0, location.href.indexOf('//'));
+      const url = location.href.split('/')[3];
+      const apiBaseUrl = `/${applicationDistribution}/${url}/ws/rest`;
+      const postData = {
+        "moduleuuid": addon.appDetails.moduleId,
+        "installuri": addon.downloadUri,
+      };
+      this.requestUrl = '/v1/moduleinstall';
+
+      axios({
+        url: `${urlPrefix}/${apiBaseUrl}${this.requestUrl}`,
+        method: 'post',
+        data: postData,
+        onUploadProgress: (event) => {
+          this.handleProgress(event);
+        }
+      }).then((response) => {
+        this.setState((prevState, props) => {
+          return {
+            showMsg: true,
+            msgBody: `${addon.appDetails.name} has been successfully installed`,
+            msgType: "success",
+            uploadStatus: 0,
+            showProgress: false,
+            files: null,
+            updatesAvailable: null,
+            progressMsg: null,
+            searchedAddons: [],
+            newAddon: null,
+            upgrading: false,
+          };
+        });
+        addonProcess === 'Upgrading' && toastr.success(`Ugrade completed successfully`);
+        this.handleApplist();
+      }).catch((error) => {
+        toastr.error(error);
+      });
+    }
+  }
+
+  confirmUpgrade() {
+    this.setState({
+      openUpgradeConfirmation: false,
+    });
+    this.state.newAddon && this.handleInstall(this.state.newAddon);
+  }
+
+  dismissUpgradeModal() {
+    this.setState({
+      openUpgradeConfirmation: false,
+      progressMsg: null,
+      newAddon: null,
+    });
+  }
+
   checkForUpdates() {
     this.setState({
       searchComplete: false
@@ -605,7 +700,11 @@ export default class ManageApps extends React.Component {
       isOpen,
       selectedApp,
       searchComplete,
-      displayInvalidZip } = this.state;
+      progressMsg,
+      upgradeAddon,
+      upgradeVersion,
+      openUpgradeConfirmation,
+      displayInvalidZip, } = this.state;
 
     if (showMsg === true) {
       setTimeout(this.handleAlertBehaviour, 6000);
@@ -697,6 +796,8 @@ export default class ManageApps extends React.Component {
                         openPage={this.openPage}
                         openModal={this.openModal}
                         handleDownload={this.handleDownload}
+                        handleInstall={this.handleInstall}
+                        handleUpgrade={this.handleUpgrade}
                         getInstalled={this.getInstalled}
                       />
                     }
@@ -713,10 +814,24 @@ export default class ManageApps extends React.Component {
             </div>
           </div>
         </div>
-        {disableUploadElements &&
+        {
+          progressMsg ?
+            <div className="waiting-modal">
+              <p className="upload-text">{progressMsg}</p>
+            </div>
+            : disableUploadElements &&
           <div className="waiting-modal">
             <p className="upload-text">Uploading {uploadStatus}%</p>
           </div>}
+        {
+          <ConfirmationModal
+            addon={upgradeAddon}
+            upgradeVersion={upgradeVersion}
+            isOpen={openUpgradeConfirmation}
+            confirmUpgrade={this.confirmUpgrade}
+            dismissUpgradeModal={this.dismissUpgradeModal}
+          />
+        }
       </div>
     );
   }

--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -29,7 +29,9 @@ export default class SingleAddon extends React.Component{
       addonParam,
       updatesVersion,
       handleDownload,
-      openPage
+      openPage,
+      handleInstall,
+      handleUpgrade,
     } = this.props;
 
     return(
@@ -61,8 +63,24 @@ export default class SingleAddon extends React.Component{
           <div><h5 className="addon-description">
             {app.appDetails && app.appDetails.description}
           </h5></div>
-          {updatesVersion ? <span className="update-notification">New version Available {updatesVersion.version} </span>: null}
-          {updatesVersion ? <span className="glyphicon glyphicon-download-alt download-update" onClick={(e) => this.getUpdate(e, updatesVersion.uid)} />: null}
+          {
+            updatesVersion ?
+              <span>
+                <span className="update-notification">New version Available {updatesVersion.version}
+                </span>
+                <span
+                  className="glyphicon glyphicon-download-alt download-update"
+                  onClick={(event) => this.getUpdate(event, updatesVersion.uid)}
+                />
+                <span
+                  className="btn btn-secondary"
+                  id="upgrade-btn"
+                  onClick={(event) => handleUpgrade(app, updatesVersion.version, updatesVersion.uid)}>Upgrade
+                </span>
+              </span>
+
+              : null
+          }
         </td>
         <td>
           {
@@ -95,11 +113,22 @@ export default class SingleAddon extends React.Component{
                 </button>
               </Link>
               :
-              <i
-                className="glyphicon glyphicon-download-alt text-primary install-icon"
-                id="icon-btn"
-                onClick={(e) => handleDownload(app.downloadUri)(e)}
-              />
+              <span>
+                <span
+                  className="btn btn-secondary"
+                  id="install-addon-btn"
+                  onClick={(event) => handleInstall(app)}>
+                  Install
+                </span>
+                <br />
+                <br />
+                <span>or </span>
+                <a href="#"
+                  className="download-link"
+                  onClick={(event) => handleDownload(app.downloadUri)(event)}>
+                  Download
+                </a>
+              </span>
           }
         </td>
       </tr>
@@ -111,5 +140,7 @@ SingleAddon.propTypes = {
   app: PropTypes.object.isRequired,
   addonParam: PropTypes.func.isRequired,
   updatesVersion: PropTypes.object.isRequired,
+  handleDownload: PropTypes.func.isRequired,
+  handleInstall: PropTypes.func.isRequired,
+  handleUpgrade: PropTypes.func.isRequired,
 };
-


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-61 Enable installation or upgrading of a module by clicking on a button](https://issues.openmrs.org/browse/AOM-61)

### SUMMARY:
Currently for a user to install or upgrade a module from the add-on index, the user has to first download the module then manually upload it in order to install/upgrade it. This PR aims to improve user experience by adding an install and an upgrade button which the user simply clicks to perform the respective action.

@kodero