### PR TITLE
AOM-91: Disable redirect for modules in search results

### DIFF
--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -55,7 +55,7 @@ export default class SingleAddon extends React.Component{
                 :
                 <div className="status-icon" id="stopped-status" />
             }
-            {app.appDetails.started === true || app.appDetails.started === false ?
+            {app.appType === "module" || app.appDetails.type === "OMOD" ?
               <span
                 className="module-click-cursor"
                 onClick={() => handleUserClick(app.appDetails.name)}>


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-91: Disable redirect for modules in search results](https://issues.openmrs.org/browse/AOM-91)
### SUMMARY:
Currently, when a user searches for an Addon, the available Addons have a link which when clicked redirects to an undefined url page
The addons in the search results should not have a clickable link