### PR TITLE
AOM-95: Change installation REST endpoint from moduleinstall to moduleaction

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -524,10 +524,11 @@ export default class ManageApps extends React.Component {
       const url = location.href.split('/')[3];
       const apiBaseUrl = `/${applicationDistribution}/${url}/ws/rest`;
       const postData = {
-        "moduleuuid": addon.appDetails.moduleId,
-        "installuri": addon.downloadUri,
+        "modules": [addon.appDetails.moduleId],
+        "action": "install",
+        "installUri": addon.downloadUri,
       };
-      this.requestUrl = '/v1/moduleinstall';
+      this.requestUrl = '/v1/moduleaction';
 
       axios({
         url: `${urlPrefix}/${apiBaseUrl}${this.requestUrl}`,


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-95 Change installation REST endpoint from moduleinstall to moduleaction](https://issues.openmrs.org/browse/AOM-95)

### SUMMARY:
The REST end point for installation was changed on [RESTWS-688](https://issues.openmrs.org/browse/RESTWS-688) based on review recommendations, this ticket reflects the same change on the front end
