### PR TITLE
AOM-104: Addons should display all names of developer/maintainer

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -155,14 +155,18 @@ export default class ManageApps extends React.Component {
       const apiBaseUrl = `/${applicationDistribution}/${url}/ws/rest`;
       this.requestUrl = '/v1/module/?v=full';
       axios.get(`${urlPrefix}/${apiBaseUrl}${this.requestUrl}`).then(response => {
-        response.data.results.forEach((data) => {
-          installedModules.push({
-            appDetails: data,
-            appType: 'module',
-            install: false
+        return Promise
+          .all(response.data.results.map(data => axios.get(`https://addons.openmrs.org/api/v1/addon/${data.packageName}`)
+          .then(response => response.data)
+          .catch((error) => data)))
+      }).then(response => {
+          response.forEach((data) => {
+            installedModules.push({
+              appDetails: data,
+              appType: 'module',
+              install: false
+            });
           });
-        });
-      }).then(() => {
         const installedAddons = installedOwas.concat(installedModules);
         this.setState((prevState, props) => {
           return {
@@ -171,7 +175,6 @@ export default class ManageApps extends React.Component {
             searchComplete: true
           };
         });
-
       });
     });
   }

--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -99,7 +99,7 @@ export default class SingleAddon extends React.Component{
               app.appDetails.author :
               app.appDetails && app.appDetails.developer ?
                 app.appDetails.developer.name :
-                app.appDetails.maintainers[0].name
+                app.appDetails.maintainers.map(maintainer => maintainer.name).join(', ')
           }
         </td>
         <td>


### PR DESCRIPTION
## JIRA TICKET NAME: [AOM-104: Addons should display all names of developer/maintainer](https://issues.openmrs.org/browse/AOM-104)

### SUMMARY:
Presently, the addon manager does not display the list of developers/maintainers names of each module.  This PR addresses the issue.