### PR TITLE
AOM-105: Searched add-ons should display after a random search

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -40,6 +40,7 @@ export default class ManageApps extends React.Component {
       files: null,
       displayInvalidZip: false,
       searchComplete: false,
+      isSearched: false,
       updatesAvailable: null,
       searchedAddons: [],
       progressMsg: null,
@@ -691,7 +692,8 @@ export default class ManageApps extends React.Component {
             this.setState({
               appList: [],
               searchedAddons: [],
-              searchComplete: true
+              searchComplete: true,
+              isSearched: true
             });
           } else {
             const searchResultsPromise = searchResults.map(result => axios.get(
@@ -708,7 +710,8 @@ export default class ManageApps extends React.Component {
                   this.setState((prevState, props) => {
                     return {
                       searchedAddons: resultData,
-                      searchComplete: true
+                      searchComplete: true,
+                      isSearched: true
                     };
                   });
                 }
@@ -719,6 +722,7 @@ export default class ManageApps extends React.Component {
                     appList: [],
                     searchedAddons: [],
                     searchComplete: true,
+                    isSearched: true
                   });}
               });
           }
@@ -729,6 +733,7 @@ export default class ManageApps extends React.Component {
               appList: [],
               searchedAddons: [],
               searchComplete: true,
+              isSearched: true,
             });
           }
         });
@@ -738,6 +743,7 @@ export default class ManageApps extends React.Component {
           appList: staticAppList,
           searchedAddons: [],
           searchComplete: true,
+          isSearched: false
         };
       });
     }
@@ -799,6 +805,7 @@ export default class ManageApps extends React.Component {
       isOpen,
       selectedApp,
       searchComplete,
+      isSearched,
       progressMsg,
       upgradeAddon,
       upgradeVersion,
@@ -908,7 +915,7 @@ export default class ManageApps extends React.Component {
                         <th>Action</th>
                       </tr>
                     </thead>
-                    {appList.length < 1 ?
+                    {searchedAddons.length < 1 && isSearched ?
                       <tbody>
                         <tr>
                           <th colSpan="5"><h4>No apps found</h4></th>

--- a/tests/components/ManageAddon.test.js
+++ b/tests/components/ManageAddon.test.js
@@ -11,6 +11,7 @@ describe('<ManageApps />', () => {
 
     // simulate a selected file in order to render upload and clear buttons
     renderedComponent.setState({
+        isSearched: true,
         files: [{
             name: "test.zip",
             type: "application/zip"


### PR DESCRIPTION
## JIRA TICKET NAME: [AOM-105: Searched add-ons should display after a random searchr](https://issues.openmrs.org/browse/AOM-105)

### SUMMARY:
Presently, when a user search for a random module like cohortbuilder , as expected there would be no result because it dosen't exist. But if the "builder" is removed from the search box to have only "cohort" string and the user makes another search, there would still be no result even though ''cohort" is a valid module search.