### PR TITLE
AOM-110: Add-On Manager remains loading when request to the Add-On index times out

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -140,6 +140,7 @@ export default class ManageApps extends React.Component {
   handleApplist() {
     const installedOwas = [];
     const installedModules = [];
+    let installedAddons = [];
 
     this.apiHelper.get('/owa/applist').then(response => {
       response.forEach((data, index) => {
@@ -157,10 +158,25 @@ export default class ManageApps extends React.Component {
       const apiBaseUrl = `/${applicationDistribution}/${url}/ws/rest`;
       this.requestUrl = '/v1/module/?v=full';
       axios.get(`${urlPrefix}/${apiBaseUrl}${this.requestUrl}`).then(response => {
+        response.data.results.forEach(data => {
+          installedModules.push({
+            appDetails: data,
+            appType: "module",
+            install: false
+          });
+        });
+        installedAddons = installedOwas.concat(installedModules);
         return Promise
           .all(response.data.results.map(data => axios.get(`${ApiHelper.getAddonUrl()}/${data.packageName}`)
           .then(response => response.data)
-          .catch((error) => data)))
+          .catch(error => {
+            this.setState((prevState, nextProps) => ({
+              appList: installedAddons,
+              staticAppList: installedAddons,
+              searchComplete: true
+            }));
+            return data;
+          })))
       }).then(response => {
           response.forEach((data) => {
             installedModules.push({
@@ -169,7 +185,7 @@ export default class ManageApps extends React.Component {
               install: false
             });
           });
-        const installedAddons = installedOwas.concat(installedModules);
+        installedAddons = installedOwas.concat(installedModules);
         this.setState((prevState, props) => {
           return {
             appList: installedAddons,


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-110: Add-On Manager remains loading when request to the Add-On index times out](https://issues.openmrs.org/browse/AOM-110)
### SUMMARY:
Currently, the Add-On Manager indefinitely shows a loading sign when trying to access the installed Add-On List and the Add-On index is down.

The installed Add-On list should not be blocked when the Add-On index is down.

Further more, during a search to the online index, the interface should stop showing the loading sign when the Add-On index is unavailable