### PR TITLE
Display appropriate message when there are no upgrades

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -915,10 +915,10 @@ export default class ManageApps extends React.Component {
                         <th>Action</th>
                       </tr>
                     </thead>
-                    {searchedAddons.length < 1 && isSearched ?
+                    {searchedAddons.length < 1 && isSearched || updatesAvailable ?
                       <tbody>
                         <tr>
-                          <th colSpan="5"><h4>No apps found</h4></th>
+                          <th colSpan="5"><h4>No {searchedAddons.length < 1 && isSearched ? 'apps': 'updates'} found</h4></th>
                         </tr>
                       </tbody> :
                       <AddonList


### PR DESCRIPTION
## JIRA TICKET NAME:

[AOM-111 Display appropriate message when there are no upgrades](https://issues.openmrs.org/browse/AOM-111)

## SUMMARY:
Currently when you click on check for updates button and all add-ons are up to date, you get a blank screen.
There is need to display an appropriate message such as No updates available for user friendliness