### PR TITLE
AOM-115: Remove duplicate list of Addons in Addon List

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -140,7 +140,7 @@ export default class ManageApps extends React.Component {
 
   handleApplist() {
     const installedOwas = [];
-    const installedModules = [];
+    let installedModules = [];
     let installedAddons = [];
 
     this.apiHelper.get('/owa/applist').then(response => {
@@ -179,6 +179,8 @@ export default class ManageApps extends React.Component {
             return data;
           })))
       }).then(response => {
+          installedAddons = [];
+          installedModules = [];
           response.forEach((data) => {
             installedModules.push({
               appDetails: data,


### PR DESCRIPTION
## JIRA TICKET NAME: [AOM-115: Remove duplicate list of Addons in Addon List](https://issues.openmrs.org/browse/AOM-115)

### SUMMARY:
Currently when the Add-on manager home page loads, it displays duplicate list of Addons on the AddonList. This PR aims to fix the issue