### PR TITLE
AOM-113: Some requests to the addon index for resources return with a status o…

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -168,7 +168,7 @@ export default class ManageApps extends React.Component {
         });
         installedAddons = installedOwas.concat(installedModules);
         return Promise
-          .all(response.data.results.map(data => axios.get(`${ApiHelper.getAddonUrl()}/${data.packageName}`)
+          .all(response.data.results.map(data => axios.get(`${ApiHelper.getAddonUrl()}?modulePackage=${data.packageName}`)
           .then(response => response.data)
           .catch(error => {
             this.setState((prevState, nextProps) => ({


### PR DESCRIPTION
## JIRA TICKET NAME
[AOM-113: Some requests to the addon index for resources return with a status of 404](https://issues.openmrs.org/browse/AOM-113)

### SUMMARY
When the Add-on manager loads, the console highlights a lot of console 404 errors.
A console error is displayed when loading the add-on manager home page as a result of an api call being made to the Add-on index before the page is loaded.
This PR address this issue
