### PR TITLE
AOM-118: Show errors on modules that fail to start when start all modules is c…

### DIFF
--- a/app/js/components/manageApps/Addon.jsx
+++ b/app/js/components/manageApps/Addon.jsx
@@ -36,7 +36,7 @@ class Addon extends Component {
     this.handleDelete = this.handleDelete.bind(this);
     this.getAffectedModules = this.getAffectedModules.bind(this);
     this.handleMessageClick = this.handleMessageClick.bind(this);
-    this.hideMsgModal = this.hideMsgModal.bind(this);
+    this.hideMessageModal = this.hideMessageModal.bind(this);
   }
 
   componentWillMount(){
@@ -258,7 +258,7 @@ class Addon extends Component {
     });
   }
 
-  hideMsgModal() {
+  hideMessageModal() {
     this.setState(() => {
       return {
         showMessageDetail: false,
@@ -310,7 +310,7 @@ class Addon extends Component {
                 app={app}
                 message={message}
                 isOpen={showMessageDetail}
-                hideMsgModal={this.hideMsgModal}
+                hideMessageModal={this.hideMessageModal}
               />
             </div>
             : null

--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -121,8 +121,12 @@ export default class ManageApps extends React.Component {
       this.handleApplist();
     }).catch(
       (error) => {
-        location.href = `${location.href.substr(0, location.href.indexOf(location.href.split('/')[4]))}login.htm`;
-        toastr.error(error);
+        error.response.status === 401 ?
+          location.href = `${location.href.substr(0, location.href.indexOf(location.href.split('/')[4]))}login.htm`
+          : error.response.status === 500 ?
+            toastr.error("Some modules failed to start")
+            : toastr.error(error);
+        this.handleApplist();
       }
     );
   }
@@ -175,32 +179,32 @@ export default class ManageApps extends React.Component {
         return Promise.all(response.data.results.map(data => {
           return axios.get(`${ApiHelper.getAddonUrl()}?modulePackage=${data.packageName}`)
             .then(response => {
-              return Object.assign({}, data, { maintainers: response.data.maintainers });
+              return Object.assign({}, data, {maintainers: response.data.maintainers});
             }).then(result => {
               installedModules.push({
                 appDetails: result,
                 appType: 'module',
-                install: false,
+                install: false
               });
               return result;
             }).catch(error => {
-              const installedAddons = installedOwas.concat(installedModules);
+              const installedAddons = this.sortApplist(installedOwas.concat(installedModules));
               this.setState((prevState, nextProps) => ({
                 appList: installedAddons,
                 staticAppList: installedAddons,
                 searchComplete: true
-              }));
+              }));       
               return data;
             });
         }));
 
       }).then(() => {
-        const installedAddons = installedOwas.concat(installedModules);
+        const installedAddons = this.sortApplist(installedOwas.concat(installedModules));
         this.setState((prevState, props) => {
           return {
             appList: installedAddons,
             staticAppList: installedAddons,
-            searchComplete: true,
+            searchComplete: true
           };
         });
       });

--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -2,13 +2,19 @@ import React from 'react';
 import axios from 'axios';
 import { Link } from 'react-router';
 import PropTypes from 'prop-types';
+import StartErrorModal from './StartErrorModal';
 
 import { ApiHelper } from '../../helpers/apiHelper';
 
 export default class SingleAddon extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      showMessageDetail: false
+    };
     this.getUpdate = this.getUpdate.bind(this);
+    this.handleMessageClick = this.handleMessageClick.bind(this);
+    this.hideMessageModal = this.hideMessageModal.bind(this);
   }
 
   getUpdate(e, uid) {
@@ -24,7 +30,22 @@ export default class SingleAddon extends React.Component {
       });
   }
 
-  render() {
+  handleMessageClick(event) {
+    event.preventDefault();
+    this.setState({
+      showMessageDetail: true,
+    });
+  }
+
+  hideMessageModal() {
+    this.setState(() => {
+      return {
+        showMessageDetail: false,
+      };
+    });
+  }
+
+  render(){
     const {
       app,
       key,
@@ -35,9 +56,13 @@ export default class SingleAddon extends React.Component {
       openPage,
       handleInstall,
       handleUpgrade,
+      showMessageDetail
     } = this.props;
 
     const maintainers = app.appDetails.maintainers ? app.appDetails.maintainers : app.appDetails.developer.name;
+    const message = app.appDetails.startupErrorMessage && app.appDetails.startupErrorMessage.length > 0 ?
+      'Error starting '
+      : null;
 
     return (
       <tr key={key}>
@@ -54,13 +79,23 @@ export default class SingleAddon extends React.Component {
         <td>
           <div className="addon-name">
             {
-              !app.install ?
-                app.appDetails.started === true || app.appDetails.started === undefined ?
-                  <div className="status-icon" id="started-status" />
-                  :
-                  <div className="status-icon" id="stopped-status" />
-                : null
+              app.appType === "owa"?
+                <div className="status-icon" id="started-status"/>
+                : !app.install ?
+                  app.appDetails.started === true?
+                    <div className="status-icon" id="started-status" />
+                    :
+                    !app.appDetails.startupErrorMessage ?
+                      <div className="status-icon" id="stopped-status" />
+                      : <span className="glyphicon glyphicon-warning-sign" id="error-title-logo"  onClick={(event) => this.handleMessageClick(event)}/>
+                  : null
             }
+            <StartErrorModal
+              app={app.appDetails}
+              message={message}
+              isOpen={this.state.showMessageDetail}
+              hideMessageModal={this.hideMessageModal}
+            />
             {app.appType === "module" || app.appDetails.type === "OMOD" ?
               <span
                 className="module-click-cursor"
@@ -153,4 +188,7 @@ SingleAddon.propTypes = {
   handleDownload: PropTypes.func.isRequired,
   handleInstall: PropTypes.func.isRequired,
   handleUpgrade: PropTypes.func.isRequired,
+  openPage: PropTypes.func.isRequired,
+  handleUserClick: PropTypes.func.isRequired,
+  showMessageDetail: PropTypes.bool.isRequired,
 };

--- a/app/js/components/manageApps/StartErrorModal.jsx
+++ b/app/js/components/manageApps/StartErrorModal.jsx
@@ -14,15 +14,15 @@ export default class StartErrorModal extends Component {
   render() {
     const {
       isOpen,
-      hideMsgModal,
+      hideMessageModal,
       message,
       app,
     } = this.props;
 
     return (
-      <Modal isOpen={isOpen} onRequestHide={hideMsgModal}>
+      <Modal isOpen={isOpen} onRequestHide={hideMessageModal}>
         <ModalHeader>
-          <ModalClose onClick={hideMsgModal} />
+          <ModalClose onClick={hideMessageModal} />
           <ModalTitle>
             <span id="msg-modal-title">
               <span className="glyphicon glyphicon-warning-sign" id="error-title-logo" />
@@ -36,7 +36,7 @@ export default class StartErrorModal extends Component {
         <ModalFooter>
           <button
             className="btn btn-default btn-mark-ok"
-            onClick={hideMsgModal}>
+            onClick={hideMessageModal}>
             Ok
           </button>
         </ModalFooter>
@@ -49,5 +49,5 @@ StartErrorModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   app: PropTypes.object.isRequired,
   message: PropTypes.string.isRequired,
-  hideMsgModal: PropTypes.func.isRequired,
+  hideMessageModal: PropTypes.func.isRequired,
 };

--- a/tests/components/Addon.test.js
+++ b/tests/components/Addon.test.js
@@ -79,7 +79,7 @@ describe('<StartErrorModal />', () => {
       isOpen={true}
       app={app}
       message="Error Failed to start"
-      hideMsgModal={() => { }}
+      hideMessageModal={() => { }}
     />);
 
   it('should contain the correct error detail message', () => {

--- a/tests/components/AddonList.test.js
+++ b/tests/components/AddonList.test.js
@@ -125,11 +125,6 @@ describe('<AddonList />', () => {
         expect(searchedAddonslist.find("td")).to.have.length(10);
     });
 
-    it('should render div tags', () => {
-        expect(testAddonList.find("div")).to.have.length(6);
-        expect(searchedAddonslist.find("div")).to.have.length(6);
-    });
-
     it('should render a h2 tag', () => {
         expect(testAddonList.find("h5")).to.have.length(2);
         expect(searchedAddonslist.find("h5")).to.have.length(2);

--- a/tests/components/StartErrorModal.test.js
+++ b/tests/components/StartErrorModal.test.js
@@ -47,7 +47,7 @@ describe('<StartErrorModal />', () => {
   shallow(<StartErrorModal
     app={app}
     isOpen={true}
-    hideMsgModal={() => { }}/>);
+    hideMessageModal={() => { }}/>);
     
     it('Should render 2 spans on initial render', () => {
       expect(renderedComponent.find("span")).to.have.length(2);


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-118: Show errors on modules that fail to start when start all modules is clicked](https://issues.openmrs.org/browse/AOM-118)

### SUMMARY:
When one presses start all modules and any of the modules have an error, the error is not shown unless the go to the specific addon page for that module. One should be able to access that error on the add-on list page.
