### PR TITLE
AOM-113_2: Some requests to the addon index for resources return with a status o…

### DIFF
--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -37,6 +37,8 @@ export default class SingleAddon extends React.Component{
       handleUpgrade,
     } = this.props;
 
+    const maintainers = app.appDetails.maintainers ? app.appDetails.maintainers : app.appDetails.developer.name;
+
     return(
       <tr key={key}>
         <td>
@@ -97,11 +99,8 @@ export default class SingleAddon extends React.Component{
         </td>
         <td>
           {
-            app.appDetails && app.appDetails.uuid ?
-              app.appDetails.author :
-              app.appDetails && app.appDetails.developer ?
-                app.appDetails.developer.name :
-                app.appDetails.maintainers.map(maintainer => maintainer.name).join(', ')
+            Array.isArray(maintainers) ?  maintainers.map(maintainer => maintainer.name).join(', ') : maintainers
+            
           }
         </td>
         <td>

--- a/tests/components/AddonList.test.js
+++ b/tests/components/AddonList.test.js
@@ -51,6 +51,12 @@ describe('<AddonList />', () => {
          "requireOpenmrsVersion":"1.7.4",
          "awareOfModules":["org.openmrs.module.legacyui"],
          "requiredModules":["org.openmrs.module.uiframework"],
+         "developer": {
+            "url": "https://github.com/openmrs/openmrs-owa-cohortbuilder",
+            "name": "andela-odaniel, wanjikum, andela-jomadoye, andela-pupendo, kingisaac95",
+            "company": null,
+            "email": null
+        },
          "links":[
            {
              "rel":"ref",

--- a/tests/components/SingleAddon.test.js
+++ b/tests/components/SingleAddon.test.js
@@ -59,6 +59,12 @@ describe('<SingleAddon/>', () => {
         "requireOpenmrsVersion":"1.7.4",
         "awareOfModules":["org.openmrs.module.legacyui"],
         "requiredModules":["org.openmrs.module.uiframework"],
+        "developer": {
+            "url":"https://github.com/openmrs/openmrs-owa-addonmanager",
+            "name":"andela-pupendo, kingisaac95, andela-wanjikum, andela-jomadoye",
+            "company":null,
+            "email":null,
+        },
         "links":[
           {
             "rel":"ref",


### PR DESCRIPTION
## JIRA TICKET NAME
[AOM-113: Some requests to the addon index for resources return with a status of 404](https://issues.openmrs.org/browse/AOM-113)

### SUMMARY
When the Add-on manager loads, the console highlights a lot of console 404 errors.
A console error is displayed when loading the add-on manager home page as a result of an api call being made to the Add-on index before the page is loaded.

This ticket has already been worked on here [https://github.com/openmrs/openmrs-owa-addonmanager/pull/113](https://github.com/openmrs/openmrs-owa-addonmanager/pull/113)

However, after it was merged, it cause some other feature in the app to break.

This PR address this issue

