### PR TITLE
AOM-116: Remove the loader when checking for updates without internet connecti…

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -699,7 +699,8 @@ export default class ManageApps extends React.Component {
       });
     }).catch(
       (error) => {
-        toastr.error(error);
+        error.message === "Network Error" ? toastr.error("There is no internet connection") : toastr.error(error.message);
+        this.handleApplist();
       }
     );
   }


### PR DESCRIPTION
## JIRA TICKET NAME:

[AOM-116 Remove the loader when checking for updates without internet connection and display an appropriate message](https://issues.openmrs.org/browse/AOM-116)

## SUMMARY:

When checking for updates without internet connection, the loader continues to load for quite some time.There is need to remove or reduce the loader time and display an appropriate message to the user while installing the list of already installed add-ons.