### PR TITLE
AOM-128: Clicking on an OWA that is not installed redirects to 404 page

### DIFF
--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -362,8 +362,11 @@ export default class ManageApps extends React.Component {
     });
   }
 
-  handleUserClick(name) {
-    toastr.info(`Sorry, there is no open web app for ${name}`);
+  handleUserClick(appType, name) {
+    appType === "OWA"?
+      toastr.info(`You would need to install the ${name} addon in order to link to it`)
+      :
+      toastr.info(`Sorry, there is no open web app for ${name}`);
   }
 
   handleUploadRequest() {

--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -89,15 +89,22 @@ export default class SingleAddon extends React.Component {
             {app.appType === "module" || app.appDetails.type === "OMOD" ?
               <span
                 className="module-click-cursor"
-                onClick={() => handleUserClick(app.appDetails.name)}>
+                onClick={() => handleUserClick(
+                  app.appType? app.appType: app.appDetails.type, app.appDetails.name)}>
                 {app.appDetails && app.appDetails.name}
               </span>
-              :
-              <span
-                className="app-details"
-                onClick={() => openPage(app.appDetails)}>
-                {app.appDetails && app.appDetails.name}
-              </span>
+              : app.install ?
+                <span
+                  className="module-click-cursor"
+                  onClick={() => handleUserClick(app.appDetails.type, app.appDetails.name)}>
+                  {app.appDetails && app.appDetails.name}
+                </span>
+                :
+                <span
+                  className="app-details"
+                  onClick={() => openPage(app.appDetails)}>
+                  {app.appDetails && app.appDetails.name}
+                </span>
             }
           </div>
           <div><h5 className="addon-description">


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-128: Clicking on an OWA that is not installed redirects to 404 page](https://issues.openmrs.org/browse/AOM-128)

### SUMMARY:
When a search is made for an app, clicking on an OWA in the search results that has not been installed redirects to a 404 page.

