### PR TITLE
AOM-134: Adjust table row for each add-ons in a uniform height

### DIFF
--- a/app/css/openmrs-addonmanager.css
+++ b/app/css/openmrs-addonmanager.css
@@ -823,3 +823,7 @@ body.loading .waiting-modal {
     font-size: 1.0em;
     padding: 5px;
 }
+
+.main-row {
+    width: 30vw;
+}

--- a/app/js/components/manageApps/SingleAddon.jsx
+++ b/app/js/components/manageApps/SingleAddon.jsx
@@ -45,6 +45,13 @@ export default class SingleAddon extends React.Component {
     });
   }
 
+  truncateAddonLength(addon) {
+    if (addon.length > 140) {
+      return `${addon.substring(0, 140)}...`;
+    }
+    return addon;
+  }
+
   render(){
     const {
       app,
@@ -66,7 +73,7 @@ export default class SingleAddon extends React.Component {
 
     return (
       <tr key={key}>
-        <td>
+        <td className="main-row">
           <div className="addon-name">
             {
               app.appType === "owa"?
@@ -108,7 +115,7 @@ export default class SingleAddon extends React.Component {
             }
           </div>
           <div><h5 className="addon-description">
-            {app.appDetails && app.appDetails.description}
+            {app.appDetails && this.truncateAddonLength(app.appDetails.description)}
           </h5></div>
           {
             updatesVersion ?
@@ -129,14 +136,18 @@ export default class SingleAddon extends React.Component {
           }
         </td>
         <td>
-          {
-            Array.isArray(maintainers) ? maintainers.map(maintainer => maintainer.name).join(', ') : maintainers
-          }
+          <h5>
+            {
+              Array.isArray(maintainers) ? this.truncateAddonLength(maintainers.map(maintainer => maintainer.name).join(', ')) : maintainers
+            }
+          </h5>
         </td>
         <td>
-          {app.appDetails.version ?
-            app.appDetails.version :
-            app.appDetails.latestVersion}
+          <h5>
+            {app.appDetails.version ?
+              app.appDetails.version :
+              app.appDetails.latestVersion}
+          </h5>
         </td>
         <td
           className="text-center"

--- a/tests/components/AddonList.test.js
+++ b/tests/components/AddonList.test.js
@@ -125,9 +125,9 @@ describe('<AddonList />', () => {
         expect(searchedAddonslist.find("td")).to.have.length(8);
     });
 
-    it('should render a h2 tag', () => {
-        expect(testAddonList.find("h5")).to.have.length(2);
-        expect(searchedAddonslist.find("h5")).to.have.length(2);
+    it('should render a h5 tag', () => {
+        expect(testAddonList.find("h5")).to.have.length(6);
+        expect(searchedAddonslist.find("h5")).to.have.length(6);
     });
     
     it('should render child table correctly', () => {


### PR DESCRIPTION
## JIRA TICKET NAME
[AOM-134: Adjust table row for each add-ons in a uniform height](https://issues.openmrs.org/browse/AOM-134)

### SUMMARY
Presently the row height for each add-on loaded on the addon manager is not uniform. This is due to the fact that some addons have more content that others hence the table cell tend to adjust to its size.

This ticket aims to address this issue