### PR TITLE
AOM-54: Adding version number to bundled OWA file name

### DIFF
--- a/app/manifest.webapp
+++ b/app/manifest.webapp
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "1.0.0-beta",
   "name": "openmrs-addOnManager",
   "description": "This will help in uploading the openmrs open web apps and omod files",
   "launch_path": "index.html",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,9 @@
   "nyc": {
     "exclude": [
       "tests/**/*.js",
+      "openmrs-addonmanager/libs/**/*.js",
+      "webpack.*.js",
+      "server.babel.js",
       "libs/**/*.js",
       "dist/**/*.js",
       "coverage/**/*.js"

--- a/webpack.sample.config.js
+++ b/webpack.sample.config.js
@@ -28,7 +28,14 @@ const WebpackOnBuildPlugin = require('on-build-webpack');
 
 const nodeModulesDir = path.resolve(__dirname, '../node_modules');
 
+require.extensions['.webapp'] = function (module, filename) {
+  module.exports = fs.readFileSync(filename, 'utf8');
+};
+const manifest = require('./app/manifest.webapp');
+
 const THIS_APP_ID = 'openmrs-addonmanager';
+
+const THIS_APP_VERSION = JSON.parse(manifest).version;
 
 let plugins = [];
 const nodeModules = {};
@@ -84,7 +91,8 @@ if (env === 'production') {
   plugins.push(new WebpackOnBuildPlugin(function(stats){
     //create zip file
     let archiver = require('archiver');
-    let output = fs.createWriteStream(THIS_APP_ID+'.zip');
+    let output = THIS_APP_VERSION ? fs.createWriteStream(`${THIS_APP_ID}-${THIS_APP_VERSION}.zip`)
+      :fs.createWriteStream(`${THIS_APP_ID}.zip`);
     let archive = archiver('zip');
 
     output.on('close', function () {


### PR DESCRIPTION
## JIRA TICKET NAME:
[AOM-54: Adding version number to bundled OWA file name](https://issues.openmrs.org/browse/AOM-54)

### SUMMARY:
Currently the .omod modules all have their version numbers at the end of its file name, however the current OWA modules naming don't follow this particular pattern. I believe this is good practice and should also be implemented by the OWA modules.
