### PR TITLE
AOM-137: Redesign warning message for an operation on a module

### DIFF
--- a/app/css/openmrs-addonmanager.css
+++ b/app/css/openmrs-addonmanager.css
@@ -827,3 +827,16 @@ body.loading .waiting-modal {
 .main-row {
     width: 30vw;
 }
+
+.warning-message {
+    font-size: 18px;
+    color: rgb(216, 39, 39);
+    position: relative;
+    top: 1vh
+}
+
+.error-message {
+    font-size: 15px;
+    position: relative;
+    right: 1vw
+}

--- a/app/js/components/manageApps/Addon.jsx
+++ b/app/js/components/manageApps/Addon.jsx
@@ -336,11 +336,20 @@ class Addon extends Component {
           <div className="title-container">
             <h3 id="addon-name">{app.name}</h3>
             <p id="addon-description">{app.description}</p>
-            {app.uid ?
-              <p id="addon-description">NOTE: Adding, removing, or starting modules will restart OpenMRS, meaning that all scheduled tasks and background processes will be interrupted.</p>
-              :
-              null
-            }
+            <div className="row">
+              {app.uid ?
+                <p className="alert-warning container-fluid" id="addon-description">
+                  <div className="col-xs-1">
+                    <span className="glyphicon glyphicon-warning-sign warning-message" />
+                  </div>
+                  <div className="col-xs-11 error-message">
+                    Adding, removing, or starting modules will restart OpenMRS, meaning that all scheduled tasks and background processes will be interrupted.
+                  </div>
+                </p>
+                :
+                null
+              }
+            </div>
           </div>
           {
             this.actionRunning()


### PR DESCRIPTION
## JIRA TICKET NAME
[AOM-137: Redesign warning message for an operation on a module](https://issues.openmrs.org/browse/AOM-137)

### SUMMARY:
Currently a message that tries to warn the user when the attempt to add, remove or start module  is not properly highlighted and the user may overlook such message. 

This ticket will fix this issue of expressly defining the warning message and bring the users attention to this message.
