### PR TITLE
AOM-139: Fix app name inconsistencies in the UI

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>openmrs-addOnManager</title>
+  <title>Add On Manager</title>
   <!-- openmrs favicon -->
   <link rel="shortcut icon" type="image/ico" href="../../images/openmrs-favicon.ico"/>
   <link rel="icon" type="image/png" href="../../images/openmrs-favicon.png"/>

--- a/app/js/components/breadCrumb/BreadCrumbComponent.jsx
+++ b/app/js/components/breadCrumb/BreadCrumbComponent.jsx
@@ -101,14 +101,14 @@ class BreadCrumbComponent extends Component {
               <span className="glyphicon glyphicon-chevron-right breadcrumb-item separator"
                 aria-hidden="true" />
               <span className="title breadcrumb-item">
-                <u>Add-on Manager</u>
+                <u>Add On Manager</u>
               </span>
             </Link> :
             <Link to="/">
               <span className="glyphicon glyphicon-chevron-right breadcrumb-item separator"
                 aria-hidden="true" />
               <span className="title breadcrumb-item">
-                <strong>Add-on Manager</strong>
+                <strong>Add On Manager</strong>
               </span>
             </Link>
         }

--- a/app/js/components/manageApps/AddAddon.jsx
+++ b/app/js/components/manageApps/AddAddon.jsx
@@ -24,7 +24,7 @@ export default class AddAddon extends Component {
     const { files } = this.props;
     if (files === null || files.length < 1) {
       return (
-        <p>Drag Add-on here to upload or
+        <p>Drag Add On here to upload or
           <a id="click-to-select" href=""
             onClick={(e) => {
               e.preventDefault(); this.state.dropzoneRef.open();

--- a/app/js/components/manageApps/ManageApps.jsx
+++ b/app/js/components/manageApps/ManageApps.jsx
@@ -95,7 +95,7 @@ export default class ManageApps extends React.Component {
         this.hideModal();
       }
     });
-    document.title = "Add-on Manager";
+    document.title = "Add On Manager";
   }
 
   startAllModules() {

--- a/webpack.sample.config.js
+++ b/webpack.sample.config.js
@@ -56,7 +56,7 @@ let getConfig = function () {
     // create file with defaults if not found
     config = {
       'LOCAL_OWA_FOLDER': '/home/sims01/openmrs/openmrs-server/owa/',
-      'APP_ENTRY_POINT': 'http://localhost:8081/openmrs-standalone/owa/openmrs-addonmanager/index.html'
+      'APP_ENTRY_POINT': 'http://localhost:8081/openmrs-standalone/owa/addonmanager/index.html'
     };
 
     fs.writeFile('config.json', JSON.stringify(config));


### PR DESCRIPTION
## JIRA TICKET NAME:

[AOM-139: Fix app name inconsistencies in the UI](https://issues.openmrs.org/browse/AOM-139)

### SUMMARY:

The app name is on the same at all occurrences on the page. This makes sure that it is always 'Add On Manager' at all places. (The window title, next to thumbnail, and in the dropzone)

