### PR TITLE
AOM-144: Fix failing test

### DIFF
--- a/tests/components/Breadcrumb.test.js
+++ b/tests/components/Breadcrumb.test.js
@@ -23,8 +23,8 @@ describe('<BreadCrumbComponent />', () => {
         expect(breadCrumb.find("span")).to.have.length(7);
     });
 
-    it('Should render a `Add-On Manager` in a span', () => {
-        expect(breadCrumb.find("span").getNodes()[2].props.children.props.children).equals("Add-on Manager");
+    it('Should render a `Add On Manager` in a span', () => {
+        expect(breadCrumb.find("span").getNodes()[2].props.children.props.children).equals("Add On Manager");
     });
 
     it('Should render a `Manage app` in a span', () => {


### PR DESCRIPTION
## JIRA TICKET NAME:

[AOM-144: Fix failing test](https://issues.openmrs.org/browse/AOM-144)

### SUMMARY:

There is a failing test concerning the spelling of the breadcrumb test. Add-on Manager instead of Add On Manager

