### PR TITLE
Add Google Analytics tag to index.html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -12,6 +12,15 @@
   <script src="libs/bootstrap-filestyle/src/bootstrap-filestyle.min.js" ></script>
   <script src="libs/toastr/toastr.min.js" ></script>
   <script src="https://unpkg.com/sweetalert/dist/sweetalert.min.js"></script>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-16695719-3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-16695719-3');
+  </script>
 </head>
 <body>  
 <div class="clear"></div>


### PR DESCRIPTION
## JIRA TICKET NAME: 
N/A

### SUMMARY:
We want to understand how many people are visiting our Add Ons page, and we have Google Analytics ready-to-go to track this. But it seems like the tag had never been added. This commit adds the tag using the code advised on the Google Analytics settings page shown here: (I didn't write the actual tag code myself, just copy-pasted)
https://analytics.google.com/analytics/web/#/a16695719w36498211p167305509/admin/tracking/tracking-code/
![image](https://user-images.githubusercontent.com/67400059/104633368-e3429d00-5653-11eb-9e9b-6713f5ae80ef.png)

